### PR TITLE
Fix comment typo in cmd/common.go

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
-// TODO decomple viper and use onctlConfig instead
+// TODO decouple viper and use onctlConfig instead
 // var onctlConfig map[string]interface{}
 
 func GenerateIDToken() uuid.UUID {


### PR DESCRIPTION
## Summary
- fix TODO comment in `cmd/common.go`

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840259bb6688322aa6c5247f1fde7a4