### PR TITLE
docs: add auto-merge instruction to PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Guidelines for developing the onctl CLI tool, a Go-based utility for managing cl
     - Technical details
     - Testing performed
     - Related issues (if any)
+  - Enable auto-merge immediately after PR creation: `gh pr merge <PR-number> --auto --squash`
 - Monitor automated CI/CD checks after PR creation:
   - Use `gh pr checks <PR-number>` to view check status
   - Common checks include: Build, Lint, Tests, Security scans, CodeQL


### PR DESCRIPTION
## Summary

Adds instruction to enable auto-merge immediately after PR creation.

## Changes

- Added auto-merge step to PR workflow in AGENTS.md
- Command: `gh pr merge <PR-number> --auto --squash`
- Should be run immediately after PR creation

## Benefits

- Ensures PRs merge automatically once all checks pass
- Reduces manual intervention needed
- Uses squash merge for cleaner git history

## Testing

- ✅ AGENTS.md syntax is valid
- ✅ Instruction is clear and actionable