### PR TITLE
feat(ssh): support -- to pass commands to remote host

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -25,6 +25,15 @@ type cmdSSHOptions struct {
 
 var sshOpt cmdSSHOptions
 
+func parseRemoteCmd(osArgs []string) []string {
+	for i, a := range osArgs {
+		if a == "--" {
+			return osArgs[i+1:]
+		}
+	}
+	return nil
+}
+
 func parseSSHConfigFile(configFile string) (*cmdSSHOptions, error) {
 	file, err := os.Open(configFile)
 	if err != nil {
@@ -176,14 +185,7 @@ var sshCmd = &cobra.Command{
 			ProcessDownloadSlice(sshOpt.DownloadFiles, remote)
 		}
 		if sshOpt.ConfigFile == "" && len(applyFileFound) == 0 && len(sshOpt.DownloadFiles) == 0 && len(sshOpt.UploadFiles) == 0 {
-			var remoteCmd []string
-			for i, a := range os.Args {
-				if a == "--" {
-					remoteCmd = os.Args[i+1:]
-					break
-				}
-			}
-			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile, remoteCmd)
+			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile, parseRemoteCmd(os.Args))
 		}
 	},
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -59,7 +59,7 @@ func init() {
 }
 
 var sshCmd = &cobra.Command{
-	Use:                   "ssh VM_NAME",
+	Use:                   "ssh VM_NAME [-- COMMAND [ARGS...]]",
 	Short:                 "Spawn an SSH connection to a VM",
 	Args:                  cobra.MinimumNArgs(1),
 	TraverseChildren:      true,
@@ -176,7 +176,7 @@ var sshCmd = &cobra.Command{
 			ProcessDownloadSlice(sshOpt.DownloadFiles, remote)
 		}
 		if sshOpt.ConfigFile == "" && len(applyFileFound) == 0 && len(sshOpt.DownloadFiles) == 0 && len(sshOpt.UploadFiles) == 0 {
-			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile)
+			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile, args[1:])
 		}
 	},
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -176,7 +176,14 @@ var sshCmd = &cobra.Command{
 			ProcessDownloadSlice(sshOpt.DownloadFiles, remote)
 		}
 		if sshOpt.ConfigFile == "" && len(applyFileFound) == 0 && len(sshOpt.DownloadFiles) == 0 && len(sshOpt.UploadFiles) == 0 {
-			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile, args[1:])
+			var remoteCmd []string
+			for i, a := range os.Args {
+				if a == "--" {
+					remoteCmd = os.Args[i+1:]
+					break
+				}
+			}
+			provider.SSHInto(args[0], sshOpt.Port, privateKeyFile, remoteCmd)
 		}
 	},
 }

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -91,7 +91,7 @@ applyFiles:
 
 func TestSSHCmd_CommandProperties(t *testing.T) {
 	// Test that the command has the expected properties
-	assert.Equal(t, "ssh VM_NAME", sshCmd.Use)
+	assert.Equal(t, "ssh VM_NAME [-- COMMAND [ARGS...]]", sshCmd.Use)
 	assert.Equal(t, "Spawn an SSH connection to a VM", sshCmd.Short)
 	assert.NotNil(t, sshCmd.Args)
 	assert.True(t, sshCmd.TraverseChildren)

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -149,6 +149,46 @@ func TestCmdSSHOptions_StructBasics(t *testing.T) {
 	assert.Equal(t, "config.yaml", opts.ConfigFile)
 }
 
+func TestParseRemoteCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		osArgs   []string
+		expected []string
+	}{
+		{
+			name:     "no separator returns nil",
+			osArgs:   []string{"onctl", "ssh", "vm"},
+			expected: nil,
+		},
+		{
+			name:     "extra args without separator returns nil",
+			osArgs:   []string{"onctl", "ssh", "vm", "uptime"},
+			expected: nil,
+		},
+		{
+			name:     "separator with single command",
+			osArgs:   []string{"onctl", "ssh", "vm", "--", "uptime"},
+			expected: []string{"uptime"},
+		},
+		{
+			name:     "separator with command and args",
+			osArgs:   []string{"onctl", "ssh", "vm", "--", "systemctl", "status", "nginx"},
+			expected: []string{"systemctl", "status", "nginx"},
+		},
+		{
+			name:     "separator at end returns empty slice",
+			osArgs:   []string{"onctl", "ssh", "vm", "--"},
+			expected: []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseRemoteCmd(tt.osArgs)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestCmdSSHOptions_ZeroValues(t *testing.T) {
 	// Test zero value cmdSSHOptions
 	var opts cmdSSHOptions

--- a/internal/cloud/aws.go
+++ b/internal/cloud/aws.go
@@ -320,7 +320,7 @@ func (p ProviderAws) GetByName(serverName string) (Vm, error) {
 	return mapAwsServer(s.Reservations[0].Instances[0]), nil
 }
 
-func (p ProviderAws) SSHInto(serverName string, port int, privateKey string) {
+func (p ProviderAws) SSHInto(serverName string, port int, privateKey string, command []string) {
 
 	s, err := p.GetByName(serverName)
 	if err != nil || s.ID == "" {
@@ -336,5 +336,6 @@ func (p ProviderAws) SSHInto(serverName string, port int, privateKey string) {
 		User:           viper.GetString("aws.vm.username"),
 		Port:           port,
 		PrivateKeyFile: privateKey,
+		Command:        command,
 	})
 }

--- a/internal/cloud/azure.go
+++ b/internal/cloud/azure.go
@@ -325,7 +325,7 @@ func (p ProviderAzure) Destroy(server Vm) error {
 
 }
 
-func (p ProviderAzure) SSHInto(serverName string, port int, privateKey string) {
+func (p ProviderAzure) SSHInto(serverName string, port int, privateKey string, command []string) {
 	s, err := p.GetByName(serverName)
 	if err != nil || s.ID == "" {
 		log.Fatalln(err)
@@ -340,6 +340,7 @@ func (p ProviderAzure) SSHInto(serverName string, port int, privateKey string) {
 		User:           viper.GetString("azure.vm.username"),
 		Port:           port,
 		PrivateKeyFile: privateKey,
+		Command:        command,
 	})
 
 }

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -75,7 +75,7 @@ type CloudProviderInterface interface {
 	// CreateSSHKey creates a new SSH key
 	CreateSSHKey(publicKeyFile string) (keyID string, err error)
 	// SSHInto connects to a VM
-	SSHInto(serverName string, port int, privateKey string)
+	SSHInto(serverName string, port int, privateKey string, command []string)
 	// GetByName gets a VM by name
 	GetByName(serverName string) (Vm, error)
 }

--- a/internal/cloud/gcp.go
+++ b/internal/cloud/gcp.go
@@ -151,7 +151,7 @@ func (p ProviderGcp) Deploy(server Vm) (Vm, error) {
 	return p.GetByName(server.Name)
 }
 
-func (p ProviderGcp) SSHInto(serverName string, port int, privateKey string) {
+func (p ProviderGcp) SSHInto(serverName string, port int, privateKey string, command []string) {
 	server, err := p.GetByName(serverName)
 	if err != nil {
 		log.Fatalln(err)
@@ -164,6 +164,7 @@ func (p ProviderGcp) SSHInto(serverName string, port int, privateKey string) {
 		User:           viper.GetString("gcp.vm.username"),
 		Port:           port,
 		PrivateKeyFile: privateKey,
+		Command:        command,
 	})
 }
 

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -226,7 +226,7 @@ func (p ProviderHetzner) GetByName(serverName string) (Vm, error) {
 	return mapHetznerServer(*s), nil
 }
 
-func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string) {
+func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string, command []string) {
 	server, _, err := p.Client.Server.GetByName(context.TODO(), serverName)
 	if server == nil {
 		fmt.Println("No Server found with name: " + serverName)
@@ -254,5 +254,6 @@ func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string)
 		User:           viper.GetString("hetzner.vm.username"),
 		Port:           port,
 		PrivateKeyFile: privateKey,
+		Command:        command,
 	})
 }

--- a/internal/tools/ssh.go
+++ b/internal/tools/ssh.go
@@ -13,6 +13,7 @@ type SSHIntoVMRequest struct {
 	User           string
 	Port           int
 	PrivateKeyFile string
+	Command        []string
 }
 
 func SSHIntoVM(request SSHIntoVMRequest) {
@@ -24,8 +25,11 @@ func SSHIntoVM(request SSHIntoVMRequest) {
 		request.IPAddress,
 		"-p", fmt.Sprint(request.Port),
 	}
+	if len(request.Command) > 0 {
+		sshArgs = append(sshArgs, "--")
+		sshArgs = append(sshArgs, request.Command...)
+	}
 	log.Println("[DEBUG] sshArgs: ", sshArgs)
-	// sshCommand := exec.Command("ssh", append(sshArgs, args[1:]...)...)
 	sshCommand := exec.Command("ssh", sshArgs...)
 	sshCommand.Stdin = os.Stdin
 	sshCommand.Stdout = os.Stdout


### PR DESCRIPTION
## Summary
- Adds Docker-style `--` command passthrough to `onctl ssh`
- `onctl ssh VM_NAME -- COMMAND [ARGS...]` runs the command on the remote instead of opening an interactive session
- Without `--`, behavior is unchanged — drops into an interactive SSH session as before

## Usage
```sh
# Run a command on the remote
onctl ssh zero -- zeroclaw --help
onctl ssh zero -- systemctl status nginx

# Interactive session (unchanged)
onctl ssh zero
```

## Test plan
- [ ] `onctl ssh <vm>` still opens interactive session
- [ ] `onctl ssh <vm> -- <cmd>` executes command on remote and exits
- [ ] Exit code from remote command is propagated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)