### PR TITLE
feat: add confirmation prompt for destroy/delete command

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -83,6 +83,12 @@ var destroyCmd = &cobra.Command{
 			// Tear down specific server
 			serverName := args[0]
 			log.Println("[DEBUG] Tear down server: " + serverName)
+			if !force {
+				fmt.Printf("This will permanently destroy VM %q and all its data. This cannot be undone.\n", serverName)
+				if !yesNo() {
+					os.Exit(0)
+				}
+			}
 			s.Start()
 			s.Suffix = " Destroying VM..."
 			if err := provider.Destroy(cloud.Vm{Name: serverName}); err != nil {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -76,7 +76,7 @@ var envDestroyCmd = &cobra.Command{
 				os.Exit(0)
 			}
 		}
-
+		force = true
 		// Destroy the VM by name
 		destroyCmd.Run(destroyCmd, []string{vmName})
 	},


### PR DESCRIPTION
## Summary

Adds interactive confirmation prompt when running `onctl destroy <name>` (or aliases: delete, rm, down) unless the `-f` / `--force` flag is passed.

This brings the destroy command in line with the confirmation UX introduced for `onctl pause` in PR #864.

## Changes
- `cmd/destroy.go`: Added confirmation dialog for single-VM destroy case (previously only `destroy all` had it).
- `cmd/env.go`: Prevent double confirmation when `onctl env destroy` delegates to the VM destroy command.

## Technical details
- Uses the existing `yesNo()` prompt (promptui) + the already-registered `force` flag.
- Descriptive message: "This will permanently destroy VM %q and all its data. This cannot be undone."
- `force = true` is set after env-level confirmation to suppress the inner VM prompt.

## Testing
- `make` (build + fmt) ✓
- `make test` (all packages pass) ✓
- `make lint` (golangci-lint: 0 issues) ✓
- Manual verification of single destroy, force flag, and env destroy paths

## Related
Follow-up to pause/resume work in #864 to ensure consistent destructive command UX.