### PR TITLE
feat: pause/resume for Hetzner only (stubs for other providers)

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -40,6 +40,12 @@ var listCmd = &cobra.Command{
 		}
 		log.Println("[DEBUG] VM List: ", serverList)
 
+		pausedList, err := provider.ListPaused()
+		if err != nil {
+			log.Println(err)
+		}
+		log.Println("[DEBUG] Paused List: ", pausedList)
+
 		switch output {
 		case "puppet":
 			var puppetInventory puppet.Inventory
@@ -75,25 +81,38 @@ var listCmd = &cobra.Command{
 				fmt.Println(server.IP, "ansible_user="+username)
 			}
 		case "json":
-			jsonList, err := json.Marshal(serverList.List)
+			combined := append(append([]cloud.Vm{}, serverList.List...), pausedList.List...)
+			jsonList, err := json.Marshal(combined)
 			if err != nil {
 				log.Println(err)
 			}
 			fmt.Println(string(jsonList))
 		case "yaml":
-			yamlList, err := yaml.Marshal(serverList.List)
+			combined := append(append([]cloud.Vm{}, serverList.List...), pausedList.List...)
+			yamlList, err := yaml.Marshal(combined)
 			if err != nil {
 				log.Println(err)
 			}
 			fmt.Println(string(yamlList))
 		default:
+			noCostTmpl := "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\n{{end}}"
+
 			switch cloudProvider {
 			case "hetzner":
 				tmpl = "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\tCOST/H\tUSAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\t{{.Cost.CostPerHour}}{{.Cost.Currency}}\t{{.Cost.AccumulatedCost}}{{.Cost.Currency}}\n{{end}}"
 			default:
-				tmpl = "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\n{{end}}"
+				tmpl = noCostTmpl
+			}
+
+			if len(pausedList.List) > 0 {
+				fmt.Printf("\033[1;32m● RUNNING (%d)\033[0m\n", len(serverList.List))
 			}
 			TabWriter(serverList, tmpl)
+
+			if len(pausedList.List) > 0 {
+				fmt.Printf("\n\033[1;33m● PAUSED (%d)\033[0m\n", len(pausedList.List))
+				TabWriter(pausedList, noCostTmpl)
+			}
 		}
 
 	},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -40,11 +40,14 @@ var listCmd = &cobra.Command{
 		}
 		log.Println("[DEBUG] VM List: ", serverList)
 
-		pausedList, err := provider.ListPaused()
-		if err != nil {
-			log.Println(err)
+		var pausedList cloud.VmList
+		if output != "puppet" && output != "ansible" {
+			pausedList, err = provider.ListPaused()
+			if err != nil {
+				log.Println(err)
+			}
+			log.Println("[DEBUG] Paused List: ", pausedList)
 		}
-		log.Println("[DEBUG] Paused List: ", pausedList)
 
 		switch output {
 		case "puppet":

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
+	"github.com/cdalar/onctl/internal/cloud"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,4 +28,22 @@ func TestListCmd_HasFlags(t *testing.T) {
 func TestListCmd_FlagDefaults(t *testing.T) {
 	// Test that default values are correct
 	assert.Equal(t, "tab", output, "output flag should default to 'tab'")
+}
+
+// TestListCmd_PausedRowRenders verifies a paused server row (as produced by
+// ListPaused) renders through TabWriter without error — the separate PAUSED table.
+func TestListCmd_PausedRowRenders(t *testing.T) {
+	paused := cloud.VmList{List: []cloud.Vm{{
+		Provider:  "hetzner",
+		ID:        "392931438",
+		Name:      "api",
+		Location:  "fsn1",
+		Type:      "ccx13",
+		IP:        "178.105.251.103",
+		PrivateIP: "N/A",
+		Status:    "paused",
+		CreatedAt: time.Now(),
+	}}}
+	tmpl := "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\n{{end}}"
+	assert.NotPanics(t, func() { TabWriter(paused, tmpl) })
 }

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cdalar/onctl/internal/cloud"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	pauseForce bool
+	pauseHot   bool
+)
+
+func init() {
+	pauseCmd.Flags().BoolVarP(&pauseForce, "force", "f", false, "pause without confirmation")
+	pauseCmd.Flags().BoolVar(&pauseHot, "hot", false, "snapshot without shutting down first (faster, crash-consistent)")
+	rootCmd.AddCommand(pauseCmd)
+	vmCmd.AddCommand(pauseCmd)
+}
+
+var pauseCmd = &cobra.Command{
+	Use:     "pause <name>",
+	Aliases: []string{"stop"},
+	Short:   "Snapshot and delete a VM to stop compute cost (keeps its IP)",
+	Long: `Pause takes a snapshot of the VM's disk, preserves its public IP, then
+deletes the VM so it no longer accrues compute cost. All data is retained in the
+snapshot. Use 'onctl resume <name>' to bring it back.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			fmt.Println("Please provide a VM name to pause")
+			return
+		}
+		serverName := args[0]
+
+		if !pauseForce {
+			fmt.Printf("This will pause VM %q to stop its compute cost. Data is preserved; resume with 'onctl resume %s'.\n", serverName, serverName)
+			if !yesNo() {
+				os.Exit(0)
+			}
+		}
+
+		fmt.Println("\033[32m✔\033[0m Pausing VM " + serverName + "... (this can take a few minutes)")
+		if err := provider.Pause(cloud.Vm{Name: serverName}, pauseHot); err != nil {
+			fmt.Println("\033[31m✘\033[0m Could not pause VM: " + serverName)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Println("\033[32m✔\033[0m VM Paused (snapshot saved, server deleted): " + serverName)
+	},
+}

--- a/cmd/pause_test.go
+++ b/cmd/pause_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPauseCmd_CommandProperties(t *testing.T) {
+	assert.Equal(t, "pause <name>", pauseCmd.Use)
+	assert.Contains(t, pauseCmd.Aliases, "stop")
+	assert.NotEmpty(t, pauseCmd.Short)
+	assert.NotNil(t, pauseCmd.Run)
+}
+
+func TestPauseCmd_HasFlags(t *testing.T) {
+	force := pauseCmd.Flags().Lookup("force")
+	assert.NotNil(t, force, "pause command should have 'force' flag")
+	assert.Equal(t, "f", force.Shorthand)
+	assert.Equal(t, "false", force.DefValue)
+
+	hot := pauseCmd.Flags().Lookup("hot")
+	assert.NotNil(t, hot, "pause command should have 'hot' flag")
+	assert.Equal(t, "false", hot.DefValue)
+}
+
+func TestPauseCmd_FlagDefaults(t *testing.T) {
+	assert.False(t, pauseForce, "force flag should default to false")
+	assert.False(t, pauseHot, "hot flag should default to false")
+}
+
+// TestPauseCmd_NoArgsReturnsEarly verifies the guard that prevents touching the
+// (nil-in-tests) provider when no VM name is given.
+func TestPauseCmd_NoArgsReturnsEarly(t *testing.T) {
+	assert.NotPanics(t, func() {
+		pauseCmd.Run(pauseCmd, []string{})
+	})
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -30,11 +30,18 @@ snapshot and re-attaches the preserved public IP when available.`,
 		}
 		serverName := args[0]
 
-		// Ensure the onctl SSH key exists and attach it (mirrors create).
-		publicKeyFile, _ := getSSHKeyFilePaths(resumePublicKeyFile)
-		keyID, err := provider.CreateSSHKey(publicKeyFile)
-		if err != nil {
-			log.Fatalln(err)
+		// Only create/ensure the SSH key in the cloud when the current provider
+		// actually supports resume (Hetzner). This avoids side-effect resource
+		// creation (e.g. key import) on AWS/Azure/GCP where Resume is a
+		// no-op stub that will fail.
+		keyID := ""
+		if _, ok := provider.(cloud.ProviderHetzner); ok {
+			publicKeyFile, _ := getSSHKeyFilePaths(resumePublicKeyFile)
+			var err error
+			keyID, err = provider.CreateSSHKey(publicKeyFile)
+			if err != nil {
+				log.Fatalln(err)
+			}
 		}
 
 		fmt.Println("\033[32m✔\033[0m Resuming VM from snapshot...")

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/cdalar/onctl/internal/cloud"
+
+	"github.com/spf13/cobra"
+)
+
+var resumePublicKeyFile string
+
+func init() {
+	resumeCmd.Flags().StringVarP(&resumePublicKeyFile, "publicKey", "k", "", "Path to publicKey file (default: ~/.ssh/id_rsa)")
+	rootCmd.AddCommand(resumeCmd)
+	vmCmd.AddCommand(resumeCmd)
+}
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume <name>",
+	Short: "Recreate a paused VM from its snapshot",
+	Long: `Resume recreates a VM previously paused with 'onctl pause' from its
+snapshot and re-attaches the preserved public IP when available.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			fmt.Println("Please provide a VM name to resume")
+			return
+		}
+		serverName := args[0]
+
+		// Ensure the onctl SSH key exists and attach it (mirrors create).
+		publicKeyFile, _ := getSSHKeyFilePaths(resumePublicKeyFile)
+		keyID, err := provider.CreateSSHKey(publicKeyFile)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		fmt.Println("\033[32m✔\033[0m Resuming VM from snapshot...")
+		vm, err := provider.Resume(cloud.Vm{Name: serverName, SSHKeyID: keyID})
+		if err != nil {
+			fmt.Println("\033[31m✘\033[0m Could not resume VM: " + serverName)
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		fmt.Println("\033[32m✔\033[0m VM Resumed: " + serverName + " (IP: " + vm.IP + ")")
+	},
+}

--- a/cmd/resume_test.go
+++ b/cmd/resume_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResumeCmd_CommandProperties(t *testing.T) {
+	assert.Equal(t, "resume <name>", resumeCmd.Use)
+	assert.NotEmpty(t, resumeCmd.Short)
+	assert.NotNil(t, resumeCmd.Run)
+}
+
+func TestResumeCmd_HasFlags(t *testing.T) {
+	key := resumeCmd.Flags().Lookup("publicKey")
+	assert.NotNil(t, key, "resume command should have 'publicKey' flag")
+	assert.Equal(t, "k", key.Shorthand)
+}
+
+// TestResumeCmd_NoArgsReturnsEarly verifies the guard that prevents touching the
+// (nil-in-tests) provider when no VM name is given.
+func TestResumeCmd_NoArgsReturnsEarly(t *testing.T) {
+	assert.NotPanics(t, func() {
+		resumeCmd.Run(resumeCmd, []string{})
+	})
+}

--- a/internal/cloud/aws.go
+++ b/internal/cloud/aws.go
@@ -330,3 +330,18 @@ func printAwsError(err error) {
 		fmt.Println(err.Error())
 	}
 }
+
+// Pause is not yet supported for AWS.
+func (p ProviderAws) Pause(server Vm, hot bool) error {
+	return fmt.Errorf("pause not supported yet for AWS (Hetzner only for now)")
+}
+
+// Resume is not yet supported for AWS.
+func (p ProviderAws) Resume(server Vm) (Vm, error) {
+	return Vm{}, fmt.Errorf("resume not supported yet for AWS (Hetzner only for now)")
+}
+
+// ListPaused returns empty for AWS (stopped instances appear in List).
+func (p ProviderAws) ListPaused() (VmList, error) {
+	return VmList{}, nil
+}

--- a/internal/cloud/azure.go
+++ b/internal/cloud/azure.go
@@ -510,3 +510,18 @@ func createNic(ctx context.Context, p *ProviderAzure, server Vm, vnet *armnetwor
 	return &nicRespDone.Interface, err
 
 }
+
+// Pause is not yet supported for Azure.
+func (p ProviderAzure) Pause(server Vm, hot bool) error {
+	return fmt.Errorf("pause not supported yet for Azure (Hetzner only for now)")
+}
+
+// Resume is not yet supported for Azure.
+func (p ProviderAzure) Resume(server Vm) (Vm, error) {
+	return Vm{}, fmt.Errorf("resume not supported yet for Azure (Hetzner only for now)")
+}
+
+// ListPaused returns empty for Azure (deallocated VMs appear in List when present).
+func (p ProviderAzure) ListPaused() (VmList, error) {
+	return VmList{}, nil
+}

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -70,10 +70,8 @@ type CloudProviderInterface interface {
 	Deploy(Vm) (Vm, error)
 	// Destroy destroys an instance
 	Destroy(Vm) error
-	// Pause stops the instance so it no longer accrues compute cost. On clouds
-	// that bill stopped instances (e.g. Hetzner) this snapshots the disk and
-	// deletes the instance; elsewhere it stops/deallocates. When hot is false the
-	// instance is gracefully shut down first (only relevant to the snapshot path).
+	// Pause stops the instance so it no longer accrues compute cost (Hetzner path
+	// snapshots+delete). Currently AWS/Azure/GCP return "not supported yet" errors.
 	Pause(server Vm, hot bool) error
 	// Resume brings a paused instance back (from snapshot or by starting it).
 	Resume(Vm) (Vm, error)

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -70,8 +70,19 @@ type CloudProviderInterface interface {
 	Deploy(Vm) (Vm, error)
 	// Destroy destroys an instance
 	Destroy(Vm) error
+	// Pause stops the instance so it no longer accrues compute cost. On clouds
+	// that bill stopped instances (e.g. Hetzner) this snapshots the disk and
+	// deletes the instance; elsewhere it stops/deallocates. When hot is false the
+	// instance is gracefully shut down first (only relevant to the snapshot path).
+	Pause(server Vm, hot bool) error
+	// Resume brings a paused instance back (from snapshot or by starting it).
+	Resume(Vm) (Vm, error)
 	// List lists all instances
 	List() (VmList, error)
+	// ListPaused lists servers that are paused but not returned by List (e.g.
+	// Hetzner pause snapshots). Providers whose List already includes stopped
+	// instances return an empty list.
+	ListPaused() (VmList, error)
 	// CreateSSHKey creates a new SSH key
 	CreateSSHKey(publicKeyFile string) (keyID string, err error)
 	// SSHInto connects to a VM

--- a/internal/cloud/gcp.go
+++ b/internal/cloud/gcp.go
@@ -187,3 +187,18 @@ func mapGcpServer(server *computepb.Instance) Vm {
 		Location:  filepath.Base(server.GetZone()),
 	}
 }
+
+// Pause is not yet supported for GCP.
+func (p ProviderGcp) Pause(server Vm, hot bool) error {
+	return fmt.Errorf("pause not supported yet for GCP (Hetzner only for now)")
+}
+
+// Resume is not yet supported for GCP.
+func (p ProviderGcp) Resume(server Vm) (Vm, error) {
+	return Vm{}, fmt.Errorf("resume not supported yet for GCP (Hetzner only for now)")
+}
+
+// ListPaused returns empty for GCP (stopped instances appear in List).
+func (p ProviderGcp) ListPaused() (VmList, error) {
+	return VmList{}, nil
+}

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -257,3 +257,300 @@ func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string,
 		Command:        command,
 	})
 }
+
+const (
+	labelOwner      = "Owner"
+	labelSnapshot   = "onctl-snapshot"
+	labelServerType = "onctl-server-type"
+	labelLocation   = "onctl-location"
+)
+
+// Pause snapshots the server's disk and then deletes the server so it stops
+// accruing compute cost (Hetzner bills powered-off servers). The primary IP(s)
+// are preserved (auto-delete disabled and labeled) so Resume can re-attach them
+// and keep the same public address. Unless hot is true, the server is gracefully
+// shut down before the snapshot so it is application-consistent.
+func (p ProviderHetzner) Pause(server Vm, hot bool) error {
+	log.Println("[DEBUG] Pause server: ", server.Name)
+	s, _, err := p.Client.Server.GetByName(context.TODO(), server.Name)
+	if err != nil {
+		return err
+	}
+	if s == nil {
+		return errors.New("No Server found with name: " + server.Name)
+	}
+
+	// Remove any previous pause snapshot for this name so they don't accumulate.
+	if old, _ := p.findPauseSnapshot(server.Name); old != nil {
+		log.Printf("[DEBUG] deleting previous pause snapshot %d\n", old.ID)
+		if _, err := p.Client.Image.Delete(context.TODO(), old); err != nil {
+			log.Println("[DEBUG] could not delete previous snapshot: ", err)
+		}
+	}
+
+	// Gracefully shut down first (unless --hot) so the snapshot is consistent.
+	if !hot {
+		if err := p.shutdownServer(s); err != nil {
+			return fmt.Errorf("shutting down server: %w", err)
+		}
+	}
+
+	desc := "onctl pause: " + server.Name
+	result, _, err := p.Client.Server.CreateImage(context.TODO(), s, &hcloud.ServerCreateImageOpts{
+		Type:        hcloud.ImageTypeSnapshot,
+		Description: &desc,
+		Labels: map[string]string{
+			labelOwner:      "onctl",
+			labelSnapshot:   server.Name,
+			labelServerType: s.ServerType.Name,
+			labelLocation:   s.Datacenter.Location.Name,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating snapshot: %w", err)
+	}
+	log.Println("[DEBUG] waiting for snapshot to complete...")
+	if err := p.Client.Action.WaitFor(context.TODO(), result.Action); err != nil {
+		return fmt.Errorf("snapshot did not complete: %w", err)
+	}
+
+	// Preserve the primary IP(s): disable auto-delete and tag them so Resume
+	// can find and re-attach them after the server is gone.
+	for _, ipID := range []int64{s.PublicNet.IPv4.ID, s.PublicNet.IPv6.ID} {
+		if ipID == 0 {
+			continue
+		}
+		_, _, err := p.Client.PrimaryIP.Update(context.TODO(), &hcloud.PrimaryIP{ID: ipID}, hcloud.PrimaryIPUpdateOpts{
+			AutoDelete: hcloud.Ptr(false),
+			Labels: hcloud.Ptr(map[string]string{
+				labelOwner:    "onctl",
+				labelSnapshot: server.Name,
+			}),
+		})
+		if err != nil {
+			log.Printf("[DEBUG] could not preserve primary IP %d: %v\n", ipID, err)
+		}
+	}
+
+	// Delete the server. Its primary IPs survive because auto-delete is now off.
+	if _, _, err := p.Client.Server.DeleteWithResult(context.TODO(), s); err != nil {
+		return fmt.Errorf("deleting server: %w", err)
+	}
+	return nil
+}
+
+// shutdownServer gracefully powers off the server (ACPI), waiting for it to
+// reach the "off" state. If it does not stop within the timeout, it falls back
+// to a hard power off so Pause never blocks indefinitely.
+func (p ProviderHetzner) shutdownServer(s *hcloud.Server) error {
+	log.Println("[DEBUG] gracefully shutting down server: ", s.Name)
+	if _, _, err := p.Client.Server.Shutdown(context.TODO(), s); err != nil {
+		return err
+	}
+
+	if p.waitForServerOff(s.ID, 60*time.Second) {
+		return nil
+	}
+
+	log.Println("[DEBUG] graceful shutdown timed out; forcing power off")
+	if _, _, err := p.Client.Server.Poweroff(context.TODO(), s); err != nil {
+		return err
+	}
+	p.waitForServerOff(s.ID, 30*time.Second)
+	return nil
+}
+
+// waitForServerOff polls the server status until it is off or the timeout
+// elapses, returning true if it reached the off state.
+func (p ProviderHetzner) waitForServerOff(id int64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(3 * time.Second)
+		cur, _, err := p.Client.Server.GetByID(context.TODO(), id)
+		if err != nil {
+			log.Println("[DEBUG] polling server status: ", err)
+			continue
+		}
+		if cur != nil && cur.Status == hcloud.ServerStatusOff {
+			return true
+		}
+	}
+	return false
+}
+
+// Resume recreates a server from the snapshot taken by Pause and re-attaches the
+// preserved primary IP(s) when they are still reserved.
+func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
+	log.Println("[DEBUG] Resume server: ", server.Name)
+	img, err := p.findPauseSnapshot(server.Name)
+	if err != nil {
+		return Vm{}, err
+	}
+	if img == nil {
+		return Vm{}, fmt.Errorf("no onctl pause snapshot found for %q", server.Name)
+	}
+
+	serverType := img.Labels[labelServerType]
+	if serverType == "" {
+		serverType = viper.GetString("hetzner.vm.type")
+	}
+	location := img.Labels[labelLocation]
+	if location == "" {
+		location = viper.GetString("hetzner.location")
+	}
+
+	opts := hcloud.ServerCreateOpts{
+		Name:       server.Name,
+		Location:   &hcloud.Location{Name: location},
+		Image:      img,
+		ServerType: &hcloud.ServerType{Name: serverType},
+		Labels:     map[string]string{labelOwner: "onctl"},
+	}
+	if server.SSHKeyID != "" {
+		if id, err := strconv.ParseInt(server.SSHKeyID, 10, 64); err == nil {
+			opts.SSHKeys = []*hcloud.SSHKey{{ID: id}}
+		}
+	}
+
+	// Re-attach any preserved primary IP(s) so the public address is unchanged.
+	if reserved := p.findReservedPrimaryIPs(server.Name); len(reserved) > 0 {
+		pubNet := &hcloud.ServerCreatePublicNet{}
+		for _, ip := range reserved {
+			switch ip.Type {
+			case hcloud.PrimaryIPTypeIPv4:
+				pubNet.EnableIPv4 = true
+				pubNet.IPv4 = ip
+			case hcloud.PrimaryIPTypeIPv6:
+				pubNet.EnableIPv6 = true
+				pubNet.IPv6 = ip
+			}
+			log.Printf("[DEBUG] re-attaching primary IP %s\n", ip.IP.String())
+		}
+		opts.PublicNet = pubNet
+	}
+
+	result, _, err := p.Client.Server.Create(context.TODO(), opts)
+	if err != nil {
+		if herr, ok := err.(hcloud.Error); ok && herr.Code == hcloud.ErrorCodeUniquenessError {
+			log.Println("Server already exists")
+			s, _, gerr := p.Client.Server.GetByName(context.TODO(), server.Name)
+			if gerr != nil {
+				return Vm{}, gerr
+			}
+			return mapHetznerServer(*s), nil
+		}
+		return Vm{}, fmt.Errorf("creating server from snapshot: %w", err)
+	}
+
+	// Wait for the server to be fully running before deleting the snapshot —
+	// the server boots from the snapshot, so deleting it prematurely breaks startup.
+	allActions := append([]*hcloud.Action{result.Action}, result.NextActions...)
+	if err := p.Client.Action.WaitFor(context.TODO(), allActions...); err != nil {
+		log.Println("[DEBUG] waiting for server actions after resume: ", err)
+	}
+
+	// Delete the pause snapshot now that the server is running — keeps
+	// ListPaused clean and avoids stale storage costs.
+	if _, err := p.Client.Image.Delete(context.TODO(), img); err != nil {
+		log.Println("[DEBUG] could not delete pause snapshot after resume: ", err)
+	}
+
+	return mapHetznerServer(*result.Server), nil
+}
+
+// findReservedPrimaryIPs returns the unassigned primary IPs preserved for the
+// given server name (those tagged by Pause and not currently attached).
+func (p ProviderHetzner) findReservedPrimaryIPs(name string) []*hcloud.PrimaryIP {
+	ips, err := p.Client.PrimaryIP.AllWithOpts(context.TODO(), hcloud.PrimaryIPListOpts{
+		ListOpts: hcloud.ListOpts{LabelSelector: labelSnapshot + "=" + name},
+	})
+	if err != nil {
+		log.Println("[DEBUG] listing primary IPs: ", err)
+		return nil
+	}
+	var reserved []*hcloud.PrimaryIP
+	for _, ip := range ips {
+		if ip.AssigneeID == 0 { // unassigned -> available to re-attach
+			reserved = append(reserved, ip)
+		}
+	}
+	return reserved
+}
+
+// ListPaused returns the servers paused via Pause, reconstructed from their
+// snapshots. The preserved primary IPv4 (tagged at pause time) is shown so the
+// user sees the address that will return on Resume.
+func (p ProviderHetzner) ListPaused() (VmList, error) {
+	images, err := p.Client.Image.AllWithOpts(context.TODO(), hcloud.ImageListOpts{
+		Type:     []hcloud.ImageType{hcloud.ImageTypeSnapshot},
+		ListOpts: hcloud.ListOpts{LabelSelector: labelOwner + "=onctl"},
+	})
+	if err != nil {
+		return VmList{}, err
+	}
+	if len(images) == 0 {
+		return VmList{}, nil
+	}
+
+	// One-shot lookup of preserved primary IPs -> map[serverName]IPv4.
+	ipByName := map[string]string{}
+	if ips, err := p.Client.PrimaryIP.AllWithOpts(context.TODO(), hcloud.PrimaryIPListOpts{
+		ListOpts: hcloud.ListOpts{LabelSelector: labelOwner + "=onctl"},
+	}); err != nil {
+		log.Println("[DEBUG] listing primary IPs for paused servers: ", err)
+	} else {
+		for _, ip := range ips {
+			if ip.Type == hcloud.PrimaryIPTypeIPv4 {
+				if name := ip.Labels[labelSnapshot]; name != "" {
+					ipByName[name] = ip.IP.String()
+				}
+			}
+		}
+	}
+
+	cloudList := make([]Vm, 0, len(images))
+	for _, img := range images {
+		name := img.Labels[labelSnapshot]
+		if name == "" {
+			continue // not an onctl pause snapshot
+		}
+		ip := ipByName[name]
+		if ip == "" {
+			ip = "N/A"
+		}
+		cloudList = append(cloudList, Vm{
+			Provider:  "hetzner",
+			ID:        strconv.FormatInt(img.ID, 10),
+			Name:      name,
+			IP:        ip,
+			PrivateIP: "N/A",
+			Type:      img.Labels[labelServerType],
+			Status:    "paused",
+			Location:  img.Labels[labelLocation],
+			CreatedAt: img.Created,
+		})
+	}
+	return VmList{List: cloudList}, nil
+}
+
+// findPauseSnapshot returns the most recent pause snapshot for the given server
+// name, or nil if none exists.
+func (p ProviderHetzner) findPauseSnapshot(name string) (*hcloud.Image, error) {
+	images, err := p.Client.Image.AllWithOpts(context.TODO(), hcloud.ImageListOpts{
+		Type:     []hcloud.ImageType{hcloud.ImageTypeSnapshot},
+		ListOpts: hcloud.ListOpts{LabelSelector: labelSnapshot + "=" + name},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(images) == 0 {
+		return nil, nil
+	}
+	latest := images[0]
+	for _, img := range images[1:] {
+		if img.Created.After(latest.Created) {
+			latest = img
+		}
+	}
+	return latest, nil
+}

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -316,10 +316,15 @@ func (p ProviderHetzner) Pause(server Vm, hot bool) error {
 
 	// Preserve the primary IP(s): disable auto-delete and tag them so Resume
 	// can find and re-attach them after the server is gone.
+	// This is best-effort for the IPs that exist, but we treat failure as fatal
+	// for the documented "keeps its IP" promise.
+	hasPrimaryIPs := false
+	preserveErrs := 0
 	for _, ipID := range []int64{s.PublicNet.IPv4.ID, s.PublicNet.IPv6.ID} {
 		if ipID == 0 {
 			continue
 		}
+		hasPrimaryIPs = true
 		_, _, err := p.Client.PrimaryIP.Update(context.TODO(), &hcloud.PrimaryIP{ID: ipID}, hcloud.PrimaryIPUpdateOpts{
 			AutoDelete: hcloud.Ptr(false),
 			Labels: hcloud.Ptr(map[string]string{
@@ -328,8 +333,13 @@ func (p ProviderHetzner) Pause(server Vm, hot bool) error {
 			}),
 		})
 		if err != nil {
+			preserveErrs++
 			log.Printf("[DEBUG] could not preserve primary IP %d: %v\n", ipID, err)
 		}
+	}
+
+	if hasPrimaryIPs && preserveErrs > 0 {
+		return fmt.Errorf("failed to preserve %d primary IP(s) — aborting pause to keep the IP reservation guarantee", preserveErrs)
 	}
 
 	// Delete the server. Its primary IPs survive because auto-delete is now off.
@@ -446,7 +456,7 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 	// the server boots from the snapshot, so deleting it prematurely breaks startup.
 	allActions := append([]*hcloud.Action{result.Action}, result.NextActions...)
 	if err := p.Client.Action.WaitFor(context.TODO(), allActions...); err != nil {
-		log.Println("[DEBUG] waiting for server actions after resume: ", err)
+		return Vm{}, fmt.Errorf("waiting for resume actions to complete: %w", err)
 	}
 
 	// Delete the pause snapshot now that the server is running — keeps

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -281,10 +281,13 @@ func (p ProviderHetzner) Pause(server Vm, hot bool) error {
 	}
 
 	// Remove any previous pause snapshot for this name so they don't accumulate.
-	if old, _ := p.findPauseSnapshot(server.Name); old != nil {
+	old, err := p.findPauseSnapshot(server.Name)
+	if err != nil {
+		log.Printf("[DEBUG] error discovering previous pause snapshot for %s: %v\n", server.Name, err)
+	} else if old != nil {
 		log.Printf("[DEBUG] deleting previous pause snapshot %d\n", old.ID)
-		if _, err := p.Client.Image.Delete(context.TODO(), old); err != nil {
-			log.Println("[DEBUG] could not delete previous snapshot: ", err)
+		if _, derr := p.Client.Image.Delete(context.TODO(), old); derr != nil {
+			log.Println("[DEBUG] could not delete previous snapshot: ", derr)
 		}
 	}
 
@@ -423,7 +426,8 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 	}
 
 	// Re-attach any preserved primary IP(s) so the public address is unchanged.
-	if reserved := p.findReservedPrimaryIPs(server.Name); len(reserved) > 0 {
+	reserved := p.findReservedPrimaryIPs(server.Name)
+	if len(reserved) > 0 {
 		pubNet := &hcloud.ServerCreatePublicNet{}
 		for _, ip := range reserved {
 			switch ip.Type {
@@ -465,6 +469,17 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 		log.Println("[DEBUG] could not delete pause snapshot after resume: ", err)
 	}
 
+	for _, ip := range reserved {
+		labels := map[string]string{labelOwner: "onctl"}
+		_, _, uerr := p.Client.PrimaryIP.Update(context.TODO(), &hcloud.PrimaryIP{ID: ip.ID}, hcloud.PrimaryIPUpdateOpts{
+			AutoDelete: hcloud.Ptr(true),
+			Labels:     hcloud.Ptr(labels),
+		})
+		if uerr != nil {
+			log.Printf("[DEBUG] could not restore primary IP %d after resume: %v\n", ip.ID, uerr)
+		}
+	}
+
 	return mapHetznerServer(*result.Server), nil
 }
 
@@ -472,7 +487,7 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 // given server name (those tagged by Pause and not currently attached).
 func (p ProviderHetzner) findReservedPrimaryIPs(name string) []*hcloud.PrimaryIP {
 	ips, err := p.Client.PrimaryIP.AllWithOpts(context.TODO(), hcloud.PrimaryIPListOpts{
-		ListOpts: hcloud.ListOpts{LabelSelector: labelSnapshot + "=" + name},
+		ListOpts: hcloud.ListOpts{LabelSelector: fmt.Sprintf("%s=%s,%s=%s", labelSnapshot, name, labelOwner, "onctl")},
 	})
 	if err != nil {
 		log.Println("[DEBUG] listing primary IPs: ", err)
@@ -548,7 +563,7 @@ func (p ProviderHetzner) ListPaused() (VmList, error) {
 func (p ProviderHetzner) findPauseSnapshot(name string) (*hcloud.Image, error) {
 	images, err := p.Client.Image.AllWithOpts(context.TODO(), hcloud.ImageListOpts{
 		Type:     []hcloud.ImageType{hcloud.ImageTypeSnapshot},
-		ListOpts: hcloud.ListOpts{LabelSelector: labelSnapshot + "=" + name},
+		ListOpts: hcloud.ListOpts{LabelSelector: fmt.Sprintf("%s=%s,%s=%s", labelSnapshot, name, labelOwner, "onctl")},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cloud/pause_resume_test.go
+++ b/internal/cloud/pause_resume_test.go
@@ -1,0 +1,30 @@
+package cloud
+
+import "testing"
+
+// Compile-time guarantee that every cloud provider implements the full
+// CloudProviderInterface, including Pause and Resume. The build breaks here if a
+// provider drops pause/resume or changes their signatures.
+var (
+	_ CloudProviderInterface = ProviderHetzner{}
+	_ CloudProviderInterface = ProviderAws{}
+	_ CloudProviderInterface = ProviderAzure{}
+	_ CloudProviderInterface = ProviderGcp{}
+)
+
+// TestAllProvidersImplementPauseResume makes the cross-provider contract explicit
+// in the suite: pause/resume is a capability every provider must offer, not a
+// Hetzner-only feature.
+func TestAllProvidersImplementPauseResume(t *testing.T) {
+	providers := map[string]any{
+		"hetzner": ProviderHetzner{},
+		"aws":     ProviderAws{},
+		"azure":   ProviderAzure{},
+		"gcp":     ProviderGcp{},
+	}
+	for name, p := range providers {
+		if _, ok := p.(CloudProviderInterface); !ok {
+			t.Errorf("provider %q does not implement CloudProviderInterface (missing Pause/Resume?)", name)
+		}
+	}
+}

--- a/internal/cloud/pause_resume_test.go
+++ b/internal/cloud/pause_resume_test.go
@@ -3,8 +3,8 @@ package cloud
 import "testing"
 
 // Compile-time guarantee that every cloud provider implements the full
-// CloudProviderInterface, including Pause and Resume. The build breaks here if a
-// provider drops pause/resume or changes their signatures.
+// CloudProviderInterface, including Pause, Resume and ListPaused. The build
+// breaks here if a provider drops any method or changes signatures.
 var (
 	_ CloudProviderInterface = ProviderHetzner{}
 	_ CloudProviderInterface = ProviderAws{}
@@ -13,8 +13,8 @@ var (
 )
 
 // TestAllProvidersImplementPauseResume makes the cross-provider contract explicit
-// in the suite: pause/resume is a capability every provider must offer, not a
-// Hetzner-only feature.
+// in the suite: every provider must implement Pause/Resume/ListPaused (current
+// stubs for non-Hetzner return "not supported yet").
 func TestAllProvidersImplementPauseResume(t *testing.T) {
 	providers := map[string]any{
 		"hetzner": ProviderHetzner{},


### PR DESCRIPTION
## Summary

Delivers pause/resume capability focused on Hetzner as the first step of the larger effort (ref #864).

- **Hetzner** gets full support:
  - `onctl pause <name>`: graceful shutdown (or `--hot`), snapshot, delete server (stops compute billing on Hetzner). Primary IPs are preserved (AutoDelete disabled + labeled with `onctl-snapshot`).
  - `onctl resume <name>`: recreates the server from the snapshot and re-attaches the original Primary IP(s) so the public IP is unchanged.
  - `onctl ls` shows paused VMs in a separate **● PAUSED** table (reconstructed from snapshots + preserved IPs).

- **AWS / Azure / GCP** get explicit stubs that return clear errors ("not supported yet (Hetzner only for now)") and empty `ListPaused`. This scopes the PR tightly and avoids prior review concerns (Azure ephemeral disks, AWS stopped instance destroyability).

- Interface additions (`Pause`, `Resume`, `ListPaused`) + cross-provider contract test included so expansion later is mechanical.

- UX aligned with reviewed patterns from the larger `feat/pause-resume` work:
  - Separate colored RUNNING/PAUSED sections in `ls`
  - `--hot` flag (Hetzner)
  - `--public-key` / `-k` for resume + automatic SSH key registration
  - Confirmation prompts + `--force`

## Testing performed
- `make` (clean build)
- `make lint` → **0 issues**
- `go test ./cmd ./internal/cloud` (including `PauseResume` contract test + list/pause/resume command tests) — all pass

Refs #864 #865

## Files changed
- New: `cmd/pause.go`, `cmd/resume.go`, `cmd/*_test.go`, `internal/cloud/pause_resume_test.go`
- Modified: `internal/cloud/cloud.go` (interface), `internal/cloud/hetzner.go` (full impl + PrimaryIP preservation), `internal/cloud/{aws,azure,gcp}.go` (stubs), `cmd/list.go` + `list_test.go`