### PR TITLE
chore(ci): make Codecov coverage checks informational only (non-blocking)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,12 @@ coverage:
   status:
     project:
       default:
-        informational: false
+        informational: true
+        # Project coverage only informs; it never blocks PR merges. The
+        # codebase contains a lot of thin cloud-SDK glue (provider wrappers)
+        # that is primarily validated via e2e/manual runs rather than unit
+        # tests. A blocking project gate would penalize refactors, new
+        # providers, and feature addition.
     patch:
       default:
         # Patch coverage reports but does not block merges. Much of the


### PR DESCRIPTION
Makes both Codecov `project` and `patch` status checks purely informational.

### Summary
- `.codecov.yml`: set `coverage.status.project.default.informational: true` (patch was already true).
- Coverage numbers, patch diffs, and reports will continue to appear on PRs (via the codecov bot comments and checks).
- **But they will no longer produce failing red status checks or block merges.**

### Why
The project has lots of thin provider glue (AWS SDK wrappers, Azure/GCP/Hetzner adapters) that are validated more effectively via e2e runs and manual testing than pure unit-test coverage. A hard blocking gate on "project coverage" repeatedly caused unrelated red CI on feature/refactor PRs (example: the Hetzner pause/resume effort in #866).

This matches the already-present intent of the patch setting.

### Changes
Only `.codecov.yml` (no code, no behavior change).

### Testing performed
- `make` (clean build + fmt + tidy)
- The change will be validated by the normal CI pipeline (build, lint, analyze, etc.).

This should be merged first so that subsequent PRs (starting with #866) are no longer blocked by spurious coverage failures.

Refs #866