### PR TITLE
feat: split onctl ls into RUNNING/PAUSED tables for all providers

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -47,6 +48,18 @@ var listCmd = &cobra.Command{
 				log.Println(err)
 			}
 			log.Println("[DEBUG] Paused List: ", pausedList)
+
+			// Partition any stopped VMs out of serverList into pausedList so all
+			// providers show the split running/paused view, not just Hetzner.
+			var running cloud.VmList
+			for _, vm := range serverList.List {
+				if isPausedStatus(vm.Status) {
+					pausedList.List = append(pausedList.List, vm)
+				} else {
+					running.List = append(running.List, vm)
+				}
+			}
+			serverList = running
 		}
 
 		switch output {
@@ -120,4 +133,13 @@ var listCmd = &cobra.Command{
 		}
 
 	},
+}
+
+// isPausedStatus reports whether a VM status means stopped/paused rather than
+// running. AWS uses "stopped", GCP uses "TERMINATED" (stopped, not deleted),
+// Azure uses "VM deallocated".
+func isPausedStatus(status string) bool {
+	return status == "stopped" ||
+		status == "TERMINATED" ||
+		strings.Contains(strings.ToLower(status), "deallocated")
 }


### PR DESCRIPTION
## Summary

Closes #872

- Hetzner already showed separate RUNNING/PAUSED tables via `ListPaused()` (snapshot-based pause). AWS, GCP, and Azure return stopped instances mixed into `List()` with provider-specific status strings.
- Added `isPausedStatus()` to detect stopped VMs: AWS `"stopped"`, GCP `"TERMINATED"` (stopped-not-deleted), Azure `"VM deallocated"`.
- After fetching `serverList`, any VM whose status matches is moved into `pausedList` before rendering — so the existing two-table display logic now fires for every provider.

## Test plan

- [ ] `onctl ls` with running instances only → single table, no headers (unchanged)
- [ ] `onctl ls` with a mix of running + stopped AWS instances → green `● RUNNING (N)` table + yellow `● PAUSED (M)` table
- [ ] Same check for GCP (`TERMINATED`) and Azure (`VM deallocated`)
- [ ] `onctl ls -o json` / `-o yaml` → flat combined array, paused VMs present with their original status string
- [ ] `onctl ls -o puppet` / `-o ansible` → only running instances listed (unchanged)
- [ ] Hetzner behaviour unchanged (still uses `ListPaused()` path)

https://claude.ai/code/session_01GTkvM3QupVmAM7nfRkkdc4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTkvM3QupVmAM7nfRkkdc4)_