### PR TITLE
refactor(hetzner): decouple provider from viper global config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cdalar/onctl/internal/tools"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -77,6 +78,13 @@ func Execute() error {
 	case "hetzner":
 		provider = &cloud.ProviderHetzner{
 			Client: providerhtz.GetClient(),
+			Config: cloud.HetznerConfig{
+				Location:      viper.GetString("hetzner.location"),
+				VMType:        viper.GetString("hetzner.vm.type"),
+				Image:         viper.GetString("hetzner.vm.image"),
+				Username:      viper.GetString("hetzner.vm.username"),
+				SSHPrivateKey: viper.GetString("ssh.privateKey"),
+			},
 		}
 	case "gcp":
 		provider = &cloud.ProviderGcp{

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -14,12 +14,20 @@ import (
 	"github.com/cdalar/onctl/internal/tools"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 )
 
+type HetznerConfig struct {
+	Location      string
+	VMType        string
+	Image         string
+	Username      string
+	SSHPrivateKey string
+}
+
 type ProviderHetzner struct {
 	Client *hcloud.Client
+	Config HetznerConfig
 }
 
 func (p ProviderHetzner) Deploy(server Vm) (Vm, error) {
@@ -33,16 +41,16 @@ func (p ProviderHetzner) Deploy(server Vm) (Vm, error) {
 	// Use server.Type if provided, otherwise fall back to config
 	serverType := server.Type
 	if serverType == "" {
-		serverType = viper.GetString("hetzner.vm.type")
+		serverType = p.Config.VMType
 	}
 
 	result, _, err := p.Client.Server.Create(context.TODO(), hcloud.ServerCreateOpts{
 		Name: server.Name,
 		Location: &hcloud.Location{
-			Name: viper.GetString("hetzner.location"),
+			Name: p.Config.Location,
 		},
 		Image: &hcloud.Image{
-			Name: viper.GetString("hetzner.vm.image"),
+			Name: p.Config.Image,
 		},
 		ServerType: &hcloud.ServerType{
 			Name: serverType,
@@ -201,11 +209,11 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 
 	serverType := img.Labels[labelServerType]
 	if serverType == "" {
-		serverType = viper.GetString("hetzner.vm.type")
+		serverType = p.Config.VMType
 	}
 	location := img.Labels[labelLocation]
 	if location == "" {
-		location = viper.GetString("hetzner.location")
+		location = p.Config.Location
 	}
 
 	opts := hcloud.ServerCreateOpts{
@@ -552,11 +560,11 @@ func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string,
 	}
 
 	if privateKey == "" {
-		privateKey = viper.GetString("ssh.privateKey")
+		privateKey = p.Config.SSHPrivateKey
 	}
 	tools.SSHIntoVM(tools.SSHIntoVMRequest{
 		IPAddress:      server.PublicNet.IPv4.IP.String(),
-		User:           viper.GetString("hetzner.vm.username"),
+		User:           p.Config.Username,
 		Port:           port,
 		PrivateKeyFile: privateKey,
 		Command:        command,


### PR DESCRIPTION
## Summary

- Add `HetznerConfig` struct with five fields: `Location`, `VMType`, `Image`, `Username`, `SSHPrivateKey`
- Add `Config HetznerConfig` field to `ProviderHetzner`; replace all `viper.GetString(...)` calls inside the provider with struct field reads
- Remove `viper` import from `hetzner.go` entirely
- Wire viper → `HetznerConfig` once in `cmd/root.go` at provider construction time

## Motivation

`ProviderHetzner` previously called `viper.GetString()` inline at call sites, coupling it to the global config singleton. This makes the provider unsafe for concurrent use in library contexts (e.g. the planned `onctl-platform` SaaS backend, where multiple requests construct providers independently). Config is now injected at construction, so the provider is stateless with respect to global state.

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./internal/cloud/...` — passes
- [ ] Manual: `go run . ls` with Hetzner config produces same output as before