### PR TITLE
refactor(hetzner): decouple ProviderHetzner from viper

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cdalar/onctl/internal/tools"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -77,6 +78,13 @@ func Execute() error {
 	case "hetzner":
 		provider = &cloud.ProviderHetzner{
 			Client: providerhtz.GetClient(),
+			Config: cloud.HetznerConfig{
+				Location:      viper.GetString("hetzner.location"),
+				Image:         viper.GetString("hetzner.vm.image"),
+				VMType:        viper.GetString("hetzner.vm.type"),
+				Username:      viper.GetString("hetzner.vm.username"),
+				SSHPrivateKey: viper.GetString("ssh.privateKey"),
+			},
 		}
 	case "gcp":
 		provider = &cloud.ProviderGcp{

--- a/internal/cloud/hetzner.go
+++ b/internal/cloud/hetzner.go
@@ -14,12 +14,20 @@ import (
 	"github.com/cdalar/onctl/internal/tools"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 )
 
+type HetznerConfig struct {
+	Location      string
+	Image         string
+	VMType        string
+	Username      string
+	SSHPrivateKey string
+}
+
 type ProviderHetzner struct {
 	Client *hcloud.Client
+	Config HetznerConfig
 }
 
 func (p ProviderHetzner) Deploy(server Vm) (Vm, error) {
@@ -30,19 +38,22 @@ func (p ProviderHetzner) Deploy(server Vm) (Vm, error) {
 		log.Fatalln(err)
 	}
 
-	// Use server.Type if provided, otherwise fall back to config
 	serverType := server.Type
 	if serverType == "" {
-		serverType = viper.GetString("hetzner.vm.type")
+		serverType = p.Config.VMType
+	}
+	location := server.Location
+	if location == "" {
+		location = p.Config.Location
 	}
 
 	result, _, err := p.Client.Server.Create(context.TODO(), hcloud.ServerCreateOpts{
 		Name: server.Name,
 		Location: &hcloud.Location{
-			Name: viper.GetString("hetzner.location"),
+			Name: location,
 		},
 		Image: &hcloud.Image{
-			Name: viper.GetString("hetzner.vm.image"),
+			Name: p.Config.Image,
 		},
 		ServerType: &hcloud.ServerType{
 			Name: serverType,
@@ -201,11 +212,11 @@ func (p ProviderHetzner) Resume(server Vm) (Vm, error) {
 
 	serverType := img.Labels[labelServerType]
 	if serverType == "" {
-		serverType = viper.GetString("hetzner.vm.type")
+		serverType = p.Config.VMType
 	}
 	location := img.Labels[labelLocation]
 	if location == "" {
-		location = viper.GetString("hetzner.location")
+		location = p.Config.Location
 	}
 
 	opts := hcloud.ServerCreateOpts{
@@ -552,11 +563,11 @@ func (p ProviderHetzner) SSHInto(serverName string, port int, privateKey string,
 	}
 
 	if privateKey == "" {
-		privateKey = viper.GetString("ssh.privateKey")
+		privateKey = p.Config.SSHPrivateKey
 	}
 	tools.SSHIntoVM(tools.SSHIntoVMRequest{
 		IPAddress:      server.PublicNet.IPv4.IP.String(),
-		User:           viper.GetString("hetzner.vm.username"),
+		User:           p.Config.Username,
 		Port:           port,
 		PrivateKeyFile: privateKey,
 		Command:        command,


### PR DESCRIPTION
## Summary

- Adds `HetznerConfig` struct (`Location`, `Image`, `VMType`, `Username`, `SSHPrivateKey`) to carry provider defaults
- `ProviderHetzner` gains a `Config HetznerConfig` field; all 7 viper calls in `hetzner.go` are replaced with struct field reads
- `cmd/root.go` populates `HetznerConfig` from viper at construction time — viper stays in the CLI layer where it belongs
- `hetzner.go` no longer imports viper, making `ProviderHetzner` usable as a plain Go library (e.g. from `onctl-platform`) without a CLI context

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/cloud/... ./cmd/...` passes
- [x] `grep viper internal/cloud/hetzner.go` returns empty