### PR TITLE
feat(hetzner): add --image flag for OS image selection

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -410,6 +410,9 @@ func MergeConfig(opt *cmdCreateOptions, config *cmdCreateOptions) {
 	if opt.Vm.Type == "" && config.Vm.Type != "" {
 		opt.Vm.Type = config.Vm.Type
 	}
+	if opt.Vm.Image == "" && config.Vm.Image != "" {
+		opt.Vm.Image = config.Vm.Image
+	}
 	if opt.Vm.SSHPort == 22 && config.Vm.SSHPort != 0 { // Default SSH port is 22
 		opt.Vm.SSHPort = config.Vm.SSHPort
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -68,6 +68,7 @@ func init() {
 	createCmd.Flags().StringVar(&opt.Domain, "domain", "", "request a domain name for the VM")
 	createCmd.Flags().StringSliceVarP(&opt.Variables, "vars", "e", []string{}, "Environment variables passed to the script")
 	createCmd.Flags().StringVarP(&opt.ConfigFile, "file", "f", "", "Path to configuration YAML file")
+	createCmd.Flags().StringVar(&opt.Vm.Image, "image", "", "OS image to use (e.g. ubuntu-22.04, fedora-42)")
 	// Register create command at root level for convenience
 	rootCmd.AddCommand(createCmd)
 	createCmd.SetUsageTemplate(createCmd.UsageTemplate() + `

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -98,6 +98,9 @@ var createCmd = &cobra.Command{
 			// Use the new MergeConfig function
 			MergeConfig(&opt, config)
 		}
+		if opt.Vm.Image != "" && cloudProvider != "hetzner" {
+			log.Fatalf("--image flag is only supported for the hetzner provider (current provider: %s)", cloudProvider)
+		}
 		s := ui.New() // Build our new spinner
 		s.Start()
 		s.Suffix = " Checking vm..."

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -30,6 +30,8 @@ type Vm struct {
 	PrivateIP string
 	// Type is the type of the instance
 	Type string `yaml:"type"`
+	// Image is the OS image to use for the instance
+	Image string `yaml:"image"`
 	// Status is the status of the instance
 	Status string
 	// Location is the location of the instance

--- a/pkg/cloud/hetzner.go
+++ b/pkg/cloud/hetzner.go
@@ -44,13 +44,19 @@ func (p ProviderHetzner) Deploy(server Vm) (Vm, error) {
 		serverType = p.Config.VMType
 	}
 
+	// Use server.Image if provided, otherwise fall back to config
+	image := server.Image
+	if image == "" {
+		image = p.Config.Image
+	}
+
 	result, _, err := p.Client.Server.Create(context.TODO(), hcloud.ServerCreateOpts{
 		Name: server.Name,
 		Location: &hcloud.Location{
 			Name: p.Config.Location,
 		},
 		Image: &hcloud.Image{
-			Name: p.Config.Image,
+			Name: image,
 		},
 		ServerType: &hcloud.ServerType{
 			Name: serverType,


### PR DESCRIPTION
## Summary

- Adds `--image` CLI flag to `onctl create` so users can specify any Hetzner OS image (e.g. `fedora-42`, `ubuntu-24.04`) instead of being locked to the default
- Adds `image` field to the `Vm` struct with yaml tag, so it can also be set via `--file` config YAML
- `Deploy()` uses the per-request image when provided, falling back to `hetzner.vm.image` from the config file
- `MergeConfig()` respects the image field with the same CLI-takes-precedence semantics as other fields

## Usage

```bash
# CLI flag
onctl create -n my-vm --image fedora-42

# Or in a --file config YAML
vm:
  image: fedora-42
```

The default (`ubuntu-22.04` from `~/.onctl/hetzner.yaml`) is unchanged when `--image` is not specified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ENYN541Kp9NUsfqLwkvJPW)_