### PR TITLE
fix(ui): stop spinner from showing previous phase's text

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -102,8 +102,8 @@ var createCmd = &cobra.Command{
 			log.Fatalf("--image flag is only supported for the hetzner provider (current provider: %s)", cloudProvider)
 		}
 		s := ui.New() // Build our new spinner
-		s.Start()
 		s.Suffix = " Checking vm..."
+		s.Start()
 		list, err := provider.List()
 		if err != nil {
 			s.Stop()
@@ -123,8 +123,8 @@ var createCmd = &cobra.Command{
 
 		// Check Domain Env
 		if opt.Domain != "" {
-			s.Start()
 			s.Suffix = " --domain flag is set... Checking Domain Env..."
+			s.Start()
 			err := domain.NewCloudFlareService().CheckEnv()
 			if err != nil {
 				s.Stop()
@@ -142,8 +142,8 @@ var createCmd = &cobra.Command{
 		log.Println("[DEBUG] publicKeyFile: ", publicKeyFile)
 		log.Println("[DEBUG] privateKeyFile: ", privateKeyFile)
 		fmt.Println("\033[32m✔\033[0m Using Public Key:", publicKeyFile)
-		s.Start()
 		s.Suffix = " Checking SSH Keys..."
+		s.Start()
 		opt.Vm.SSHKeyID, err = provider.CreateSSHKey(publicKeyFile)
 		if err != nil {
 			s.Stop()
@@ -163,18 +163,16 @@ var createCmd = &cobra.Command{
 				opt.Vm.Name = tools.GenerateMachineUniqueName()
 			}
 		}
-		s.Restart()
 		s.Suffix = " VM Starting..."
+		s.Restart()
 		// END Set VM Name
 
 		vm, err := provider.Deploy(opt.Vm)
 		if err != nil {
 			log.Println(err)
 		}
-		s.Restart()
-		s.Suffix = " VM IP: " + vm.IP
 		s.Stop()
-		fmt.Println("\033[32m✔\033[0m" + s.Suffix)
+		fmt.Println("\033[32m✔\033[0m VM IP: " + vm.IP)
 
 		log.Println("[DEBUG] Vm:" + vm.String())
 		privateKey, err := os.ReadFile(privateKeyFile)
@@ -197,8 +195,8 @@ var createCmd = &cobra.Command{
 
 		// BEGIN Domain
 		if opt.Domain != "" {
-			s.Restart()
 			s.Suffix = " Requesting Domain..."
+			s.Restart()
 			_, err := domain.NewCloudFlareService().SetRecord(&domain.SetRecordRequest{
 				Subdomain: opt.Domain,
 				Ipaddress: vm.IP,
@@ -213,15 +211,15 @@ var createCmd = &cobra.Command{
 		}
 
 		if cloudProvider != "firecracker" {
-			s.Restart()
 			s.Suffix = " Waiting for VM to be ready..."
+			s.Restart()
 			remote.WaitForCloudInit(viper.GetString("vm.cloud-init.timeout"))
 			s.Stop()
 			fmt.Println("\033[32m✔\033[0m VM is Ready")
 			log.Println("[DEBUG] cloud-init finished")
 		} else {
-			s.Restart()
 			s.Suffix = " Waiting for SSH to be ready..."
+			s.Restart()
 			remote.WaitForSSH(viper.GetString("vm.cloud-init.timeout"))
 			s.Stop()
 			fmt.Println("\033[32m✔\033[0m VM is Ready")
@@ -229,8 +227,8 @@ var createCmd = &cobra.Command{
 		}
 		// END Cloud-init
 
-		s.Restart()
 		s.Suffix = " Configuring VM..."
+		s.Restart()
 		if opt.DotEnvFile != "" {
 			dotEnvVars, err := tools.ParseDotEnvFile(opt.DotEnvFile)
 			if err != nil {
@@ -246,8 +244,8 @@ var createCmd = &cobra.Command{
 
 		// BEGIN Apply File
 		for i, applyFile := range applyFileFound {
-			s.Restart()
 			s.Suffix = " Running " + opt.ApplyFiles[i] + " on Remote..."
+			s.Restart()
 
 			err = remote.CopyAndRunRemoteFile(&tools.CopyAndRunRemoteFileConfig{
 				File: applyFile,

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -72,8 +72,8 @@ func checkDockerHubImage(image string) bool {
 // runContainer runs a Docker container on the remote VM
 func runContainer(remote tools.Remote, s *ui.Spinner, image string, env []string, name string) {
 	// Step 3: Run Docker container on remote VM
-	s.Restart()
 	s.Suffix = " Starting Docker container on remote VM..."
+	s.Restart()
 
 	// Prepare environment variables
 	envVars := ""
@@ -143,8 +143,8 @@ func runContainer(remote tools.Remote, s *ui.Spinner, image string, env []string
 	fmt.Printf("\033[32m\u2714\033[0m Docker container started successfully (ID: %s)\033[?25h\n", containerID)
 
 	// Step 4: Clean up uploaded tar file (only if it exists)
-	s.Restart()
 	s.Suffix = " Cleaning up temporary files..."
+	s.Restart()
 
 	cleanupCmd := "rm image.tar.gz 2>/dev/null || true"
 	_, err = remote.RemoteRun(&tools.RemoteRunConfig{
@@ -412,16 +412,16 @@ Note: Ensure the Docker image architecture matches the remote VM's architecture 
 					filled := int(float64(current) / float64(total) * float64(progressBarWidth))
 					bar := strings.Repeat("█", filled) + strings.Repeat("░", progressBarWidth-filled)
 
-					s.Suffix = fmt.Sprintf(" Uploading... %.1f%% [%s] (%.1f/%.1f MB) %.1f MBit/s",
-						percentage, bar, float64(current)/(1024*1024), fileSizeMB, mbitsPerSecond)
+					s.SetSuffix(fmt.Sprintf(" Uploading... %.1f%% [%s] (%.1f/%.1f MB) %.1f MBit/s",
+						percentage, bar, float64(current)/(1024*1024), fileSizeMB, mbitsPerSecond))
 				} else {
 					// First callback, speed not yet available
 					progressBarWidth := 20
 					filled := int(float64(current) / float64(total) * float64(progressBarWidth))
 					bar := strings.Repeat("█", filled) + strings.Repeat("░", progressBarWidth-filled)
 
-					s.Suffix = fmt.Sprintf(" Uploading... %.1f%% [%s] (%.1f/%.1f MB)",
-						percentage, bar, float64(current)/(1024*1024), fileSizeMB)
+					s.SetSuffix(fmt.Sprintf(" Uploading... %.1f%% [%s] (%.1f/%.1f MB)",
+						percentage, bar, float64(current)/(1024*1024), fileSizeMB))
 				}
 			}
 
@@ -448,8 +448,8 @@ Note: Ensure the Docker image architecture matches the remote VM's architecture 
 			fmt.Println("\033[32m\u2714\033[0m Docker image uploaded to remote VM\033[?25h")
 
 			// Step 4: Load Docker image on remote VM
-			s.Restart()
 			s.Suffix = " Loading Docker image on remote VM..."
+			s.Restart()
 
 			loadCmd := "gunzip -c image.tar.gz | docker load"
 			_, err = remote.RemoteRun(&tools.RemoteRunConfig{

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -67,8 +67,8 @@ var destroyCmd = &cobra.Command{
 				wg.Add(1)
 				go func(server cloud.Vm) {
 					defer wg.Done()
-					s.Start()
 					s.Suffix = " Destroying VM..."
+					s.Start()
 					if err := provider.Destroy(server); err != nil {
 						fmt.Println("\033[31m✘\033[0m Could not destroy VM: " + server.Name)
 						log.Println(err)
@@ -89,8 +89,8 @@ var destroyCmd = &cobra.Command{
 					os.Exit(0)
 				}
 			}
-			s.Start()
 			s.Suffix = " Destroying VM..."
+			s.Start()
 			if err := provider.Destroy(cloud.Vm{Name: serverName}); err != nil {
 				s.Stop()
 				fmt.Println("\033[31m✘\033[0m Cannot destroy VM: " + serverName)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -165,8 +165,8 @@ var sshCmd = &cobra.Command{
 
 		// BEGIN Apply File
 		for i, applyFile := range applyFileFound {
-			s.Restart()
 			s.Suffix = " Running " + sshOpt.ApplyFiles[i] + " on Remote..."
+			s.Restart()
 
 			err = remote.CopyAndRunRemoteFile(&tools.CopyAndRunRemoteFileConfig{
 				File: applyFile,

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -31,10 +31,16 @@ func (m model) Init() tea.Cmd {
 	return m.spinner.Tick
 }
 
+// suffixMsg updates the spinner suffix while the program is running
+type suffixMsg string
+
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg.(type) {
+	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		return m, tea.Quit
+	case suffixMsg:
+		m.suffix = string(msg)
+		return m, nil
 	default:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
@@ -136,7 +142,7 @@ func (s *Spinner) SetSuffix(suffix string) {
 	s.model.suffix = suffix
 
 	if s.isRunning && s.program != nil {
-		s.program.Send(s.model)
+		s.program.Send(suffixMsg(suffix))
 	}
 }
 

--- a/internal/ui/spinner_test.go
+++ b/internal/ui/spinner_test.go
@@ -94,6 +94,19 @@ func TestSpinnerSuffix(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 }
 
+func TestModelUpdateSuffixMsg(t *testing.T) {
+	// The running tea program must apply suffix changes sent by SetSuffix;
+	// otherwise the spinner keeps rendering the previous phase's text.
+	m := model{suffix: " old phase"}
+
+	updated, _ := m.Update(suffixMsg(" new phase"))
+
+	got := updated.(model).suffix
+	if got != " new phase" {
+		t.Errorf("Expected rendered suffix %q, got %q", " new phase", got)
+	}
+}
+
 func TestSpinnerActive(t *testing.T) {
 	s := New()
 


### PR DESCRIPTION
## Problem

During `onctl up`, the VM IP line is shown twice:

```
✔ VM IP: 167.233.64.66
⢿  VM IP: 167.233.64.66
```

The bubbletea-based spinner wrapper (`internal/ui/spinner.go`) only syncs `Suffix` into the rendered model on `Start()`/`Restart()`, but the cmd code assigned `s.Suffix` *after* calling `Start()`/`Restart()` (the old briandowns/spinner pattern). So every phase's spinner rendered the previous phase's text — after printing `✔ VM IP: …`, the spinner restarted for the cloud-init wait but kept displaying the stale ` VM IP: …` suffix.

A second latent bug: `SetSuffix()` sent the updated model to the running program, but the tea model's `Update()` had no case to receive it, so mid-run suffix changes were silently dropped — which also left the deploy upload progress bar frozen.

## Changes

- `internal/ui/spinner.go`: add a `suffixMsg` case to the tea model's `Update` so `SetSuffix` actually updates a running spinner
- `cmd/create.go`, `cmd/deploy.go`, `cmd/ssh.go`, `cmd/destroy.go`: set `s.Suffix` before `Start()`/`Restart()` at every call site
- deploy's upload progress callback now uses `SetSuffix()` so the progress bar updates live
- drop the pointless `Restart()`/`Stop()` pair around the VM IP println in create.go
- add `TestModelUpdateSuffixMsg` verifying suffix changes reach the renderer

## Verification

- `go build ./...`, `go vet` clean
- full test suite passes; `go test -race ./internal/ui/...` passes
- `golangci-lint run` reports 0 issues
- grep confirms no remaining Start/Restart-before-Suffix orderings

🤖 Generated with [Claude Code](https://claude.com/claude-code)