### PR TITLE
feat: add recursive directory upload support via SFTP

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -287,6 +287,24 @@ func getSSHKeyFilePaths(filename string) (publicKeyFile, privateKeyFile string) 
 	return publicKeyFile, privateKeyFile
 }
 
+func dirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			size += info.Size()
+		}
+		return nil
+	})
+	return size, err
+}
+
 func ProcessUploadSlice(uploadSlice []string, remote tools.Remote) {
 	if len(uploadSlice) == 0 {
 		return
@@ -316,8 +334,23 @@ func ProcessUploadSlice(uploadSlice []string, remote tools.Remote) {
 			log.Printf("[ERROR] Failed to stat %s: %v", localFile, err)
 			continue
 		}
-		totalBytes := fileInfo.Size()
-		fmt.Printf("Uploading file: %s -> %s (%.1f MB)\n", localFile, remoteFile, float64(totalBytes)/(1024*1024))
+
+		var totalBytes int64
+		if fileInfo.IsDir() {
+			totalBytes, err = dirSize(localFile)
+			if err != nil {
+				log.Printf("[ERROR] Failed to calculate size of %s: %v", localFile, err)
+				continue
+			}
+		} else {
+			totalBytes = fileInfo.Size()
+		}
+
+		if fileInfo.IsDir() {
+			fmt.Printf("Uploading directory: %s -> %s (%.1f MB)\n", localFile, remoteFile, float64(totalBytes)/(1024*1024))
+		} else {
+			fmt.Printf("Uploading file: %s -> %s (%.1f MB)\n", localFile, remoteFile, float64(totalBytes)/(1024*1024))
+		}
 
 		startTime := time.Now()
 		progressCallback := func(current, total int64) {
@@ -342,15 +375,25 @@ func ProcessUploadSlice(uploadSlice []string, remote tools.Remote) {
 			fmt.Printf("\r[%s] %5.1f%% (%.1f/%.1f MB) %.1f MB/s", bar, percentage, float64(current)/(1024*1024), float64(total)/(1024*1024), mbPerSecond)
 		}
 
-		err = remote.SSHCopyFileWithProgress(localFile, remoteFile, progressCallback)
-		if err != nil {
-			fmt.Print("\n")
-			log.Printf("[ERROR] Failed to upload %s: %v", localFile, err)
-			continue
+		if fileInfo.IsDir() {
+			err = remote.SSHUploadDir(localFile, remoteFile, totalBytes, progressCallback)
+			if err != nil {
+				fmt.Print("\n")
+				log.Printf("[ERROR] Failed to upload directory %s: %v", localFile, err)
+				continue
+			}
+			progressCallback(totalBytes, totalBytes)
+			fmt.Printf("\n\033[32m\u2714\033[0m Uploaded directory %s\n", remoteFile)
+		} else {
+			err = remote.SSHCopyFileWithProgress(localFile, remoteFile, progressCallback)
+			if err != nil {
+				fmt.Print("\n")
+				log.Printf("[ERROR] Failed to upload %s: %v", localFile, err)
+				continue
+			}
+			progressCallback(totalBytes, totalBytes)
+			fmt.Printf("\n\033[32m\u2714\033[0m Uploaded %s\n", remoteFile)
 		}
-
-		progressCallback(totalBytes, totalBytes)
-		fmt.Printf("\n\033[32m\u2714\033[0m Uploaded %s\n", remoteFile)
 	}
 
 	if spinnerWasActive {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -300,6 +300,71 @@ func TestGetSSHKeyFilePaths(t *testing.T) {
 	}
 }
 
+func TestDirSize(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dirsize-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Top-level file
+	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("12345"), 0o600); err != nil {
+		t.Fatalf("Failed to write file1: %v", err)
+	}
+
+	// Nested directory with a file
+	subDir := filepath.Join(tmpDir, "subdir")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "file2.txt"), []byte("1234567890"), 0o600); err != nil {
+		t.Fatalf("Failed to write file2: %v", err)
+	}
+
+	size, err := dirSize(tmpDir)
+	if err != nil {
+		t.Fatalf("dirSize returned error: %v", err)
+	}
+
+	expected := int64(len("12345") + len("1234567890"))
+	if size != expected {
+		t.Errorf("Expected size %d, got %d", expected, size)
+	}
+}
+
+func TestDirSize_NonExistentPath(t *testing.T) {
+	_, err := dirSize("/nonexistent/path/for/dirsize-test")
+	if err == nil {
+		t.Error("Expected error for non-existent path, got nil")
+	}
+}
+
+func TestProcessUploadSlice_Directory(t *testing.T) {
+	mockRemote := tools.Remote{
+		Username:   "test",
+		IPAddress:  "127.0.0.1",
+		SSHPort:    22,
+		PrivateKey: "fake-key",
+	}
+
+	tmpDir, err := os.MkdirTemp("", "upload-dir-test-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	// Without a real SSH server, SSHUploadDir will fail to connect, but
+	// ProcessUploadSlice should handle that gracefully (log and continue)
+	// rather than panicking.
+	assert.NotPanics(t, func() {
+		ProcessUploadSlice([]string{tmpDir + ":/remote/dir"}, mockRemote)
+	})
+}
+
 func TestProcessUploadSlice(t *testing.T) {
 	// Mock Remote struct
 	mockRemote := tools.Remote{

--- a/internal/tools/scp.go
+++ b/internal/tools/scp.go
@@ -3,9 +3,11 @@ package tools
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/pkg/sftp"
 )
@@ -175,6 +177,79 @@ func (r *Remote) SSHCopyFileWithProgress(srcPath, dstPath string, progressCallba
 	}
 
 	return nil
+}
+
+// SSHUploadDir recursively uploads a local directory to a remote path via SFTP.
+// totalBytes should be the pre-calculated total size of the directory for progress reporting.
+func (r *Remote) SSHUploadDir(srcDir, dstDir string, totalBytes int64, progressCallback func(current, total int64)) error {
+	sftpClient, err := r.newSFTPClient(false, true)
+	if err != nil {
+		return fmt.Errorf("failed to create SFTP client for upload: %w", err)
+	}
+	defer func() {
+		if err := sftpClient.Close(); err != nil {
+			log.Printf("Failed to close SFTP client: %v", err)
+		}
+	}()
+
+	var uploadedBytes int64
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path: %w", err)
+		}
+		remotePath := filepath.Join(dstDir, relPath)
+
+		if d.IsDir() {
+			return sftpClient.MkdirAll(remotePath)
+		}
+
+		srcFile, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open %s: %w", path, err)
+		}
+		defer func() {
+			if err := srcFile.Close(); err != nil {
+				log.Printf("Failed to close source file: %v", err)
+			}
+		}()
+
+		dstFile, err := sftpClient.Create(remotePath)
+		if err != nil {
+			return fmt.Errorf("failed to create remote file %s: %w", remotePath, err)
+		}
+		defer func() {
+			if err := dstFile.Close(); err != nil {
+				log.Printf("Failed to close remote file: %v", err)
+			}
+		}()
+
+		buffer := make([]byte, progressCopyBufferSize)
+		for {
+			n, readErr := srcFile.Read(buffer)
+			if n > 0 {
+				written, writeErr := dstFile.Write(buffer[:n])
+				if writeErr != nil {
+					return writeErr
+				}
+				uploadedBytes += int64(written)
+				if progressCallback != nil {
+					progressCallback(uploadedBytes, totalBytes)
+				}
+			}
+			if readErr == io.EOF {
+				break
+			}
+			if readErr != nil {
+				return readErr
+			}
+		}
+		return nil
+	})
 }
 
 func (r *Remote) SCPCopyFileWithProgress(srcPath, dstPath string, progressCallback func(current, total int64)) error {

--- a/internal/tools/scp_test.go
+++ b/internal/tools/scp_test.go
@@ -160,6 +160,35 @@ func TestSSHCopyFileWithProgress_EmptyFile(t *testing.T) {
 	}
 }
 
+func TestSSHUploadDir_NoSSHConnection(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "scp-upload-dir-")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	if err := os.WriteFile(tmpDir+"/file1.txt", []byte("content"), 0o600); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+
+	r := &Remote{
+		Username:   "test",
+		IPAddress:  "127.0.0.1",
+		SSHPort:    22,
+		PrivateKey: "fake-key",
+	}
+
+	// This will fail because we can't actually connect, but should return a
+	// wrapped error rather than panicking.
+	err = r.SSHUploadDir(tmpDir, "/remote/dir", 7, nil)
+	if err == nil {
+		t.Error("Expected error without valid SSH connection, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create SFTP client for upload") {
+		t.Errorf("Expected specific error message, got: %v", err)
+	}
+}
+
 func TestDownloadFile_NonExistentFile(t *testing.T) {
 	r := &Remote{
 		Username:   "test",


### PR DESCRIPTION
## Summary
- Adds `SSHUploadDir` method to `Remote` that recursively uploads a local directory via SFTP
- Extends `ProcessUploadSlice` to detect directories and route to the new method
- Adds `dirSize` helper to pre-calculate total bytes for accurate progress reporting

## Test plan
- [ ] Upload a single file — existing behavior unchanged
- [ ] Upload a directory — verify all files/subdirectories appear on remote
- [ ] Progress bar updates continuously across all files in the tree
- [ ] Error mid-upload (e.g. permission denied on a file) surfaces a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)