### PR TITLE
fix(ci): resolve three recurring workflow warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,5 +85,5 @@ jobs:
         continue-on-error: true
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.txt
+          files: ./coverage.txt
           fail_ci_if_error: false

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -45,7 +45,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
-          version: latest
+          version: "~> v2"
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GH_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,7 @@ release:
     name: onctl
   prerelease: auto
 
-brews:
+homebrew_casks:
   - repository:
       owner: cdalar
       name: homebrew-tap


### PR DESCRIPTION
## Summary

Three pre-existing warnings surfaced in the goreleaser run for v0.1.24:

- **goreleaser.yml**: `version: latest` → `"~> v2"` — suppresses the "Will lock to '~> v2'" warning printed on every release run
- **.goreleaser.yml**: `brews:` → `homebrew_casks:` — goreleaser v2 deprecation; `brews` key is no longer supported
- **build.yml**: `file: ./coverage.txt` → `files:` — codecov-action v7 removed the `file` input in favour of `files`

All three are one-line mechanical fixes; no behaviour changes.

## Test plan

- [ ] Next goreleaser run should not print "Will lock to '~> v2'" or "DEPRECATED: brews" warnings
- [ ] Next build run should not print "Unexpected input(s) 'file'" warning in Upload Coverage step

🤖 Generated with [Claude Code](https://claude.com/claude-code)