### PR TITLE
fix(goreleaser): merge build blocks and increase timeout to 120m

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release
+          args: release --timeout 120m
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GH_TOKEN }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,41 +13,21 @@ before:
 
 builds:
   - binary: onctl
-    id: onctl-linux
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    ldflags:
-      - -w -s -X 'github.com/cdalar/onctl/cmd.Version=v{{.Version}}-{{.ShortCommit}}'
-
-  - binary: onctl
-    id: onctl-windows
-    env:
-      - CGO_ENABLED=0
-    goos:
-      - windows
-    goarch:
-      - amd64
-    ldflags:
-      - -w -s -X 'github.com/cdalar/onctl/cmd.Version=v{{.Version}}-{{.ShortCommit}}'
-
-  - binary: onctl
     id: onctl
     env:
       - CGO_ENABLED=0
     goos:
+      - linux
       - darwin
+      - windows
     goarch:
       - amd64
-      - arm64 # M1 Chip
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -w -s -X 'github.com/cdalar/onctl/cmd.Version=v{{.Version}}-{{.ShortCommit}}'
-    # hooks:
-    #   post: ["gon gon/config-{{.Arch}}.json"]
 
 
 archives:


### PR DESCRIPTION
## Summary

- **Root cause**: Three separate `builds:` blocks in `.goreleaser.yml` caused goreleaser to cross-compile linux+windows sequentially before darwin, consuming the entire 1-hour default timeout. v0.1.25 hit exactly 59m49s on builds alone, leaving no time for archiving/release.
- **Fix 1**: Merge the three build blocks into one — all 5 targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64) now run concurrently in a single parallelism pool.
- **Fix 2**: Add `--timeout 120m` to goreleaser-action args as a safety net for slow runners.

## Test plan

- [ ] All platforms cross-compile locally: `GOOS=windows GOARCH=amd64 go build ./...` ✓, `GOOS=linux GOARCH=arm64 go build ./...` ✓, `GOOS=darwin GOARCH=amd64 go build ./...` ✓
- [ ] Goreleaser CI passes on next tag push