### PR TITLE
ci: add Go cross-compile cache warm-up cron (every 5 days)

### DIFF
--- a/.github/workflows/warm-go-cache.yml
+++ b/.github/workflows/warm-go-cache.yml
@@ -1,0 +1,26 @@
+name: warm-go-cache
+
+on:
+  schedule:
+    - cron: '0 2 */5 * *'  # every 5 days — keeps cache alive under GitHub's 7-day eviction window
+  workflow_dispatch:
+
+jobs:
+  warm:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+      - name: Pre-build stdlib for cross-compile targets
+        run: |
+          GOOS=linux  GOARCH=amd64 go build std &
+          GOOS=linux  GOARCH=arm64 go build std &
+          GOOS=windows GOARCH=amd64 go build std &
+          GOOS=darwin GOARCH=amd64 go build std &
+          wait


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/warm-go-cache.yml` that runs every 5 days on `macos-latest`
- Pre-builds the Go stdlib for all 4 cross-compile targets in parallel: `linux/amd64`, `linux/arm64`, `windows/amd64`, `darwin/amd64`
- Keeps the `actions/setup-go` build cache alive under GitHub's 7-day eviction window
- Also has `workflow_dispatch` for manual triggering

## Why

`goreleaser` cross-compiles linux binaries from macOS, which requires building the entire Go stdlib for `GOOS=linux` from scratch (~81 minutes on a cold cache). With a warm cache, subsequent runs skip stdlib compilation and drop to ~5-10 minutes. Release cadence is >7 days so the cache would otherwise always be cold.

## Test plan

- [ ] Trigger manually via `workflow_dispatch` to verify it runs and populates the cache
- [ ] On next goreleaser release, confirm build time drops significantly