### PR TITLE
feat(cli): add -p short flag for --provider

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -149,7 +149,7 @@ func downloadFile(url, filepath string) error {
 }
 
 func init() {
-	actionCmd.Flags().StringVarP(&actionParamsFile, "params", "p", "", "JSON parameter file to pass as stdin")
+	actionCmd.Flags().StringVarP(&actionParamsFile, "params", "j", "", "JSON parameter file to pass as stdin")
 	actionCmd.Flags().String("github-owner", "cdalar", "GitHub owner/org to download action binaries from")
 	_ = viper.BindPFlag("actions.githubOwner", actionCmd.Flags().Lookup("github-owner"))
 	rootCmd.AddCommand(actionCmd)

--- a/cmd/action_test.go
+++ b/cmd/action_test.go
@@ -25,7 +25,7 @@ func TestActionCmd_HasFlags(t *testing.T) {
 		shorthand string
 		usage     string
 	}{
-		{"params", "p", "JSON parameter file to pass as stdin"},
+		{"params", "j", "JSON parameter file to pass as stdin"},
 	}
 
 	for _, flag := range flags {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -75,7 +75,7 @@ func init() {
 	createCmd.Flags().StringSliceVarP(&opt.DownloadFiles, "download", "d", []string{}, "List of files to download")
 	createCmd.Flags().StringSliceVarP(&opt.UploadFiles, "upload", "u", []string{}, "List of files to upload")
 	createCmd.Flags().StringVarP(&opt.Vm.Name, "name", "n", "", "vm name")
-	createCmd.Flags().IntVarP(&opt.Vm.SSHPort, "ssh-port", "p", 22, "ssh port")
+	createCmd.Flags().IntVarP(&opt.Vm.SSHPort, "ssh-port", "P", 22, "ssh port")
 	createCmd.Flags().StringVarP(&opt.Vm.CloudInitFile, "cloud-init", "i", "", "cloud-init file")
 	createCmd.Flags().StringVar(&opt.DotEnvFile, "dot-env", "", "dot-env (.env) file")
 	createCmd.Flags().StringVar(&opt.Domain, "domain", "", "request a domain name for the VM")

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -114,7 +114,7 @@ func TestCreateCmd_HasFlags(t *testing.T) {
 		{"download", "d", "List of files to download"},
 		{"upload", "u", "List of files to upload"},
 		{"name", "n", "vm name"},
-		{"ssh-port", "p", "ssh port"},
+		{"ssh-port", "P", "ssh port"},
 		{"cloud-init", "i", "cloud-init file"},
 		{"dot-env", "", "dot-env (.env) file"},
 		{"domain", "", "request a domain name for the VM"},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,7 +185,7 @@ func initProvider(cloudProvider string) {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&providerFlag, "provider", "", "cloud provider: "+strings.Join(cloudProviderList, ", ")+" (overrides ONCTL_CLOUD)")
+	rootCmd.PersistentFlags().StringVarP(&providerFlag, "provider", "p", "", "cloud provider: "+strings.Join(cloudProviderList, ", ")+" (overrides ONCTL_CLOUD)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -56,7 +56,7 @@ func parseSSHConfigFile(configFile string) (*cmdSSHOptions, error) {
 
 func init() {
 	sshCmd.Flags().StringVarP(&sshOpt.Key, "key", "k", "", "Path to privateKey file (default: ~/.ssh/id_rsa))")
-	sshCmd.Flags().IntVarP(&sshOpt.Port, "port", "p", 22, "ssh port")
+	sshCmd.Flags().IntVarP(&sshOpt.Port, "port", "P", 22, "ssh port")
 	sshCmd.Flags().StringSliceVarP(&sshOpt.ApplyFiles, "apply-file", "a", []string{}, "bash script file(s) to run on remote")
 	sshCmd.Flags().StringSliceVarP(&sshOpt.DownloadFiles, "download", "d", []string{}, "List of files to download")
 	sshCmd.Flags().StringSliceVarP(&sshOpt.UploadFiles, "upload", "u", []string{}, "List of files to upload")

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -109,7 +109,7 @@ func TestSSHCmd_HasFlags(t *testing.T) {
 		defValue  string
 	}{
 		{"key", "k", "Path to privateKey file (default: ~/.ssh/id_rsa))", ""},
-		{"port", "p", "ssh port", "22"},
+		{"port", "P", "ssh port", "22"},
 		{"apply-file", "a", "bash script file(s) to run on remote", "[]"},
 		{"download", "d", "List of files to download", "[]"},
 		{"upload", "u", "List of files to upload", "[]"},


### PR DESCRIPTION
Make --provider a globally usable short flag (-p) on the persistent root flag set. Since Cobra panics when a subcommand redefines a persistent shorthand, relocate the colliding short flags:

- ssh --port:      -p -> -P (matches scp/sftp -P convention)
- create --ssh-port: -p -> -P
- action --params:   -p -> -j

Update flag assertions in the affected tests.


Claude-Session: https://claude.ai/code/session_01EGdJJHgKUfLaNTJd5JbeXg