### PR TITLE
ci: make quill install runner-agnostic, verify it's on PATH

### DIFF
--- a/.github/workflows/goreleaser-self-hosted-test.yml
+++ b/.github/workflows/goreleaser-self-hosted-test.yml
@@ -31,7 +31,11 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
       - name: install quill
-        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+        run: |
+          curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: verify quill
+        run: quill version
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.2.2
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -30,7 +30,11 @@ jobs:
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
       - name: install quill
-        run: curl -sSfL https://get.anchore.io/quill | sudo sh -s -- -b /usr/local/bin
+        run: |
+          curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+      - name: verify quill
+        run: quill version
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.2.2
         with:


### PR DESCRIPTION
## Summary
- Follow-up to #923. The quill install step used `sudo` and hardcoded `/usr/local/bin`, which isn't safe to assume across different runners (self-hosted, containers, different OS/arch).
- Installs to `$RUNNER_TEMP/bin` instead (always writable, no sudo needed) and adds it to `$GITHUB_PATH`.
- Adds an explicit `quill version` step right after install, so a broken/missing install fails loudly with a clear error instead of failing deep inside the GoReleaser build hook.

## Test plan
- [x] YAML syntax validated for both workflow files
- [ ] Confirm `quill version` step passes on the next workflow run (macos-latest and the self-hosted macOS/ARM64 runner)