### PR TITLE
ci: run release workflow on self-hosted runner

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Switches the tag-triggered \`goreleaser.yml\` release workflow from \`macos-latest\` to the self-hosted \`[self-hosted, macOS, ARM64]\` runner (Cemals-Mac-mini), making self-hosted the permanent release runner going forward.
- Matches the runner already used (and validated) in \`goreleaser-self-hosted-test.yml\`.

## Test plan
- [x] Confirmed the self-hosted runner is online and idle
- [ ] After merge, push a new tag and confirm the release completes on self-hosted, including quill signing/notarization