### PR TITLE
feat(create): expose AWS config as CLI flags; drop required aws.yaml

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -117,19 +117,19 @@ func ReadConfig(cloudProvider string) error {
 		return fmt.Errorf("no configuration directory found in current directory or home directory. Please run `onctl init` first")
 	}
 
-	// Set paths for general and cloud provider-specific config
-	configFile := filepath.Join(configDir, cloudProvider+".yaml")
-	log.Println("[DEBUG] Config File Path:", configFile)
-
-	if _, err := os.Stat(configFile); os.IsNotExist(err) {
-		return fmt.Errorf("no configuration file found for %s in %s", cloudProvider, configDir)
-	}
-
 	viper.SetConfigName("onctl") // General config
 	viper.AddConfigPath(configDir)
 
 	if err := viper.ReadInConfig(); err != nil {
 		log.Printf("Failed to read general config: %v", err)
+	}
+
+	// Set path for cloud provider-specific config
+	configFile := filepath.Join(configDir, cloudProvider+".yaml")
+	log.Println("[DEBUG] Config File Path:", configFile)
+
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		return fmt.Errorf("no configuration file found for %s in %s", cloudProvider, configDir)
 	}
 
 	viper.SetConfigName(cloudProvider) // Specific config

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -48,7 +48,7 @@ func GenerateIDToken() uuid.UUID {
 
 // setDefaults registers built-in defaults for every setting that was
 // previously supplied by the YAML files written by `onctl init`. With these in
-// place onctl works for Hetzner and Firecracker with no .onctl config present; CLI flags and an
+// place onctl works for Hetzner, Firecracker and AWS with no .onctl config present; CLI flags and an
 // existing .onctl config still override them (viper precedence: flag > env >
 // config > default). See ROADMAP/PR: "Remove onctl's YAML config in favor of
 // CLI flags with defaults (Hetzner)".
@@ -63,6 +63,18 @@ func setDefaults() {
 	viper.SetDefault("hetzner.vm.type", "cpx21")
 	viper.SetDefault("hetzner.vm.image", "ubuntu-22.04")
 	viper.SetDefault("hetzner.vm.username", "root")
+	// AWS (was aws.yaml). aws.vm.image is left undefaulted here:
+	// provideraws.GetImages already falls back to the Ubuntu AMI name
+	// pattern when it's empty.
+	viper.SetDefault("aws.location", "eu-central-1")
+	viper.SetDefault("aws.vm.type", "t2.micro")
+	viper.SetDefault("aws.vm.username", "ubuntu")
+	// GCP (was gcp.yaml). gcp.project has no static default: initState()
+	// falls back to `gcloud config get-value project` for it, and fails
+	// fast if that's also empty.
+	viper.SetDefault("gcp.zone", "europe-west4-a")
+	viper.SetDefault("gcp.type", "n1-standard-1")
+	viper.SetDefault("gcp.vm.username", "root")
 	// Firecracker (was fc.yaml). providerfc.GetConfig also
 	// defaults these for direct package use; kept here so the values are part
 	// of the CLI config layer (and so kernelImage/rootfsImage, which GetConfig

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -153,6 +153,13 @@ var createCmd = &cobra.Command{
 
 			// Use the new MergeConfig function
 			MergeConfig(&opt, config)
+			// AWS reads the image purely through the aws.vm.image viper key
+			// (see provideraws.GetImages), not opt.Vm.Image, so a config-file
+			// vm.image needs to be copied across; the --image flag already
+			// binds to both via viper.BindPFlag.
+			if cloudProvider == "aws" && opt.Vm.Image != "" {
+				viper.Set("aws.vm.image", opt.Vm.Image)
+			}
 		}
 		if opt.Vm.Image != "" && cloudProvider != "hetzner" && cloudProvider != "aws" {
 			log.Fatalf("--image flag is only supported for the hetzner and aws providers (current provider: %s)", cloudProvider)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -96,9 +96,17 @@ func init() {
 	_ = viper.BindPFlag("hetzner.location", createCmd.Flags().Lookup("location"))
 	_ = viper.BindPFlag("hetzner.vm.username", createCmd.Flags().Lookup("username"))
 	_ = viper.BindPFlag("vm.cloud-init.timeout", createCmd.Flags().Lookup("cloud-init-timeout"))
-	// --image keeps an empty flag default (so the non-hetzner guard below and
+	// --image keeps an empty flag default (so the image guard below and
 	// opt.Vm.Image stay empty when unset); viper supplies the real default.
 	_ = viper.BindPFlag("hetzner.vm.image", createCmd.Flags().Lookup("image"))
+
+	// AWS. Same generic flags, bound to the aws.* keys read by
+	// provideraws/pkg/cloud/aws.go. Defaults match the previous aws.yaml; see
+	// setDefaults() in common.go.
+	_ = viper.BindPFlag("aws.vm.type", createCmd.Flags().Lookup("type"))
+	_ = viper.BindPFlag("aws.location", createCmd.Flags().Lookup("location"))
+	_ = viper.BindPFlag("aws.vm.username", createCmd.Flags().Lookup("username"))
+	_ = viper.BindPFlag("aws.vm.image", createCmd.Flags().Lookup("image"))
 
 	// Firecracker-specific flags. These replace the embedded fc.yaml
 	// written by `onctl init`: each is bound to the fc.* key read by
@@ -146,8 +154,8 @@ var createCmd = &cobra.Command{
 			// Use the new MergeConfig function
 			MergeConfig(&opt, config)
 		}
-		if opt.Vm.Image != "" && cloudProvider != "hetzner" {
-			log.Fatalf("--image flag is only supported for the hetzner provider (current provider: %s)", cloudProvider)
+		if opt.Vm.Image != "" && cloudProvider != "hetzner" && cloudProvider != "aws" {
+			log.Fatalf("--image flag is only supported for the hetzner and aws providers (current provider: %s)", cloudProvider)
 		}
 		s := ui.New() // Build our new spinner
 		s.Suffix = " Checking vm..."

--- a/cmd/flags_defaults_test.go
+++ b/cmd/flags_defaults_test.go
@@ -55,20 +55,38 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		{"fc-binary", "fc.binPath", "firecracker", "/usr/local/bin/firecracker"},
 		{"vcpu", "fc.vcpuCount", "1", "4"},
 		{"memory", "fc.memSizeMib", "512", "2048"},
+		// AWS (replaces aws.yaml).
+		{"type", "aws.vm.type", "t2.micro", "m5.large"},
+		{"location", "aws.location", "eu-central-1", "us-east-1"},
+		{"username", "aws.vm.username", "ubuntu", "ec2-user"},
 	}
+	// Check every default before mutating any flag. Several keys share a
+	// flag with a different per-provider default (e.g. --type backs both
+	// hetzner.vm.type=cpx21 and aws.vm.type=t2.micro): once a flag is marked
+	// Changed -- even by setting it back to its original value -- viper's
+	// flag layer outranks SetDefault for every key bound to that flag, so
+	// checking defaults and overrides in the same pass would make later
+	// cases see the wrong "default".
 	for _, c := range cases {
-		// Default (flag unchanged) resolves via the binding.
 		assert.Equal(t, c.def, viper.GetString(c.key), "default for %s", c.key)
-		// Override flows through.
+	}
+	assert.Equal(t, "root", viper.GetString("fc.vm.username"))
+
+	for _, c := range cases {
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.override))
 		assert.Equal(t, c.override, viper.GetString(c.key), "override for %s", c.key)
-		// Restore so other tests see the default again.
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.def))
 	}
 
-	// The generic --username flag drives the Firecracker microVM user too.
-	assert.Equal(t, "root", viper.GetString("fc.vm.username"))
-	assert.NoError(t, createCmd.Flags().Set("username", "ubuntu"))
-	assert.Equal(t, "ubuntu", viper.GetString("fc.vm.username"))
+	// The generic --username flag drives the Firecracker and AWS users too.
+	assert.NoError(t, createCmd.Flags().Set("username", "admin"))
+	assert.Equal(t, "admin", viper.GetString("fc.vm.username"))
+	assert.Equal(t, "admin", viper.GetString("aws.vm.username"))
+
+	// Restore the shared flags to their own intrinsic defaults (not
+	// whichever per-provider case happened to run last) so sibling tests in
+	// this package see the same state as before this test ran.
+	assert.NoError(t, createCmd.Flags().Set("type", "cpx21"))
+	assert.NoError(t, createCmd.Flags().Set("location", "fsn1"))
 	assert.NoError(t, createCmd.Flags().Set("username", "root"))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,8 +103,8 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
-// initState resolves the cloud provider and loads its config. Hetzner and fc
-// have built-in defaults (see setDefaults), so a missing .onctl is
+// initState resolves the cloud provider and loads its config. Hetzner, fc and
+// aws have built-in defaults (see setDefaults), so a missing .onctl is
 // best-effort for them; every other provider still requires its YAML config,
 // so a missing or unreadable config stays a fatal error, matching the
 // pre-flags behavior.
@@ -113,7 +113,7 @@ func initState() error {
 	cloudProvider = checkCloudProvider()
 	log.Println("[DEBUG] Cloud: " + cloudProvider)
 	if err := ReadConfig(cloudProvider); err != nil {
-		if cloudProvider != "hetzner" && cloudProvider != "fc" {
+		if cloudProvider != "hetzner" && cloudProvider != "fc" && cloudProvider != "aws" {
 			return err
 		}
 		log.Println("[DEBUG] no config file loaded, using defaults:", err)

--- a/internal/files/init/aws.yaml
+++ b/internal/files/init/aws.yaml
@@ -1,6 +1,0 @@
-aws:
-  location: eu-central-1
-  vm:
-    type: t2.micro
-    username: ubuntu
-    image: ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*


### PR DESCRIPTION
## Summary
- Mirrors the Hetzner zero-YAML pass (#918) for AWS: `aws.location`/`aws.vm.type`/`aws.vm.username` now have built-in defaults (matching the deleted `aws.yaml`), and the existing generic `--type`/`--location`/`--username`/`--image` create flags are bound to the AWS viper keys too.
- `--image` is now accepted for `aws` as well as `hetzner` (AWS reads it purely via the `aws.vm.image` viper key, not `opt.Vm.Image`, which stays Hetzner-only/snapshot-ID logic).
- Removes the embedded `internal/files/init/aws.yaml`; `onctl init` no longer scaffolds it, and a missing `.onctl` is no longer fatal for `aws`.
- First of a 3-PR follow-up to #918/#919 (AWS → GCP → Azure) so no provider requires `onctl init`/YAML anymore.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` passes (full suite)
- [x] Extended `cmd/flags_defaults_test.go` with AWS cases; restructured the shared-flag assertions into a defaults-check pass then an override pass (documented why in the test comment)