### PR TITLE
feat(ls): multi-provider support for onctl ls

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/cdalar/onctl/internal/tools"
 	"github.com/cdalar/onctl/internal/tools/puppet"
 	"github.com/cdalar/onctl/pkg/cloud"
 
@@ -24,6 +25,56 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 }
 
+// namedProvider pairs a provider client with the name it was built for, so
+// results can be tagged and per-provider settings (e.g. vm.username) looked
+// up correctly when aggregating across providers.
+type namedProvider struct {
+	name     string
+	provider cloud.CloudProviderInterface
+}
+
+// resolveProviderNames decides which provider name(s) `ls` queries. An
+// explicit --provider/ONCTL_CLOUD always means exactly one, matching every
+// other command. Otherwise, if more than one provider's credentials are
+// detected, `ls` aggregates across all of them; with zero or one detected,
+// it falls back to the already-resolved single provider (unchanged
+// behavior). Kept separate from resolveListProviders so the decision can be
+// tested without constructing real provider clients (which, for gcp/azure,
+// can log.Fatal without credentials).
+func resolveProviderNames() []string {
+	if !providerExplicitlyChosen {
+		if names := tools.DetectCloudProviders(); len(names) > 1 {
+			return names
+		}
+	}
+	return []string{cloudProvider}
+}
+
+// resolveListProviders builds a provider client for each name returned by
+// resolveProviderNames, reusing the already-built global provider rather
+// than constructing a second client when there's only one.
+func resolveListProviders() []namedProvider {
+	names := resolveProviderNames()
+	log.Printf("[DEBUG] ls multi names=%v explicit=%v primary=%s", names, providerExplicitlyChosen, cloudProvider)
+	out := make([]namedProvider, 0, len(names))
+	for _, n := range names {
+		if len(names) == 1 && n == cloudProvider {
+			out = append(out, namedProvider{n, provider})
+			continue
+		}
+		// Best-effort load this provider's config into viper (hetzner/aws/fc
+		// may not have a yaml; azure/gcp may need subscription/project etc).
+		_ = ReadConfig(n)
+		p := buildProvider(n)
+		if p == nil {
+			log.Printf("[DEBUG] skipping provider %s: no client", n)
+			continue
+		}
+		out = append(out, namedProvider{n, p})
+	}
+	return out
+}
+
 var listCmd = &cobra.Command{
 	Use:     "ls",
 	Aliases: []string{"list"},
@@ -33,19 +84,25 @@ var listCmd = &cobra.Command{
 		var (
 			tmpl       string
 			serverList cloud.VmList
-			err        error
 		)
-		serverList, err = provider.List()
-		if err != nil {
-			log.Println(err)
+		providers := resolveListProviders()
+		for _, np := range providers {
+			l, err := np.provider.List()
+			if err != nil {
+				log.Printf("[DEBUG] ls provider %s: %v", np.name, err)
+			}
+			serverList.List = append(serverList.List, l.List...)
 		}
 		log.Println("[DEBUG] VM List: ", serverList)
 
 		var pausedList cloud.VmList
 		if output != "puppet" && output != "ansible" {
-			pausedList, err = provider.ListPaused()
-			if err != nil {
-				log.Println(err)
+			for _, np := range providers {
+				pl, err := np.provider.ListPaused()
+				if err != nil {
+					log.Printf("[DEBUG] ls provider %s ListPaused: %v", np.name, err)
+				}
+				pausedList.List = append(pausedList.List, pl.List...)
 			}
 			log.Println("[DEBUG] Paused List: ", pausedList)
 
@@ -82,18 +139,14 @@ var listCmd = &cobra.Command{
 
 			encoder := yaml.NewEncoder(os.Stdout)
 			encoder.SetIndent(2) // Set YAML indentation
-			err = encoder.Encode(puppetInventory)
-			if err != nil {
+			if err := encoder.Encode(puppetInventory); err != nil {
 				log.Println(err)
 			}
 		case "ansible":
 			log.Println("[DEBUG] Ansible output")
-			username := viper.GetString(cloudProvider + ".vm.username")
-			if err != nil {
-				log.Println(err)
-			}
 			fmt.Println("[onctl]")
 			for _, server := range serverList.List {
+				username := viper.GetString(server.Provider + ".vm.username")
 				fmt.Println(server.IP, "ansible_user="+username)
 			}
 		case "json":
@@ -113,10 +166,11 @@ var listCmd = &cobra.Command{
 			fmt.Println(string(yamlList))
 		default:
 			noCostTmpl := "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\n{{end}}"
-			switch cloudProvider {
-			case "hetzner":
+			// The cost column is Hetzner-specific, so it only applies when
+			// ls resolved to exactly that one provider, not when aggregating.
+			if len(providers) == 1 && providers[0].name == "hetzner" {
 				tmpl = "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\tCOST/H\tUSAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\t{{.Cost.CostPerHour}}{{.Cost.Currency}}\t{{.Cost.AccumulatedCost}}{{.Cost.Currency}}\n{{end}}"
-			default:
+			} else {
 				tmpl = noCostTmpl
 			}
 			// When there are paused servers, label both groups so they read as

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -60,8 +60,8 @@ func TestResolveProviderNames(t *testing.T) {
 	t.Setenv("HOME", cleanHome)
 	origDir, _ := os.Getwd()
 	tmp := t.TempDir()
-	os.Chdir(tmp)
-	defer os.Chdir(origDir)
+	require.NoError(t, os.Chdir(tmp))
+	defer func() { require.NoError(t, os.Chdir(origDir)) }()
 
 	envVars := []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AZURE_CLIENT_ID", "GOOGLE_CREDENTIALS", "HCLOUD_TOKEN"}
 	for _, v := range envVars {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	"github.com/cdalar/onctl/pkg/cloud"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListCmd_CommandProperties(t *testing.T) {
@@ -46,4 +48,81 @@ func TestListCmd_PausedRowRenders(t *testing.T) {
 	}}}
 	tmpl := "CLOUD\tID\tNAME\tLOCATION\tTYPE\tPUBLIC IP\tPRIVATE IP\tSTATE\tAGE\n{{range .List}}{{.Provider}}\t{{.ID}}\t{{.Name}}\t{{.Location}}\t{{.Type}}\t{{.IP}}\t{{.PrivateIP}}\t{{.Status}}\t{{durationFromCreatedAt .CreatedAt}}\n{{end}}"
 	assert.NotPanics(t, func() { TabWriter(paused, tmpl) })
+}
+
+// TestResolveProviderNames covers the provider-selection decision in
+// isolation from provider construction (which, for gcp/azure, can log.Fatal
+// without real credentials -- see resolveListProviders in list.go).
+func TestResolveProviderNames(t *testing.T) {
+	// Isolate detection from on-disk yamls (home + repo .onctl) so Detect only sees
+	// the envs we set in subtests. Matches how the logic was tested originally.
+	cleanHome := t.TempDir()
+	t.Setenv("HOME", cleanHome)
+	origDir, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
+	envVars := []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "AZURE_CLIENT_ID", "GOOGLE_CREDENTIALS", "HCLOUD_TOKEN"}
+	for _, v := range envVars {
+		require.NoError(t, os.Unsetenv(v))
+	}
+
+	originalExplicit := providerExplicitlyChosen
+	originalCloudProvider := cloudProvider
+	defer func() {
+		providerExplicitlyChosen = originalExplicit
+		cloudProvider = originalCloudProvider
+	}()
+
+	t.Run("explicit provider, multiple credentials present, still single", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
+		providerExplicitlyChosen = true
+		cloudProvider = "aws"
+		assert.Equal(t, []string{"aws"}, resolveProviderNames())
+	})
+
+	t.Run("not explicit, zero or one credential detected, falls back to resolved provider", func(t *testing.T) {
+		providerExplicitlyChosen = false
+		cloudProvider = "hetzner"
+		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
+		assert.Equal(t, []string{"hetzner"}, resolveProviderNames())
+	})
+
+	t.Run("not explicit, multiple credentials detected, aggregates all", func(t *testing.T) {
+		providerExplicitlyChosen = false
+		cloudProvider = "aws"
+		t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
+		assert.Equal(t, []string{"aws", "hetzner"}, resolveProviderNames())
+	})
+}
+
+func TestBuildProvider_UnknownReturnsNil(t *testing.T) {
+	p := buildProvider("not-a-real-provider")
+	assert.Nil(t, p)
+}
+
+func TestResolveListProviders_IncludesNamed(t *testing.T) {
+	// Save/restore global provider state touched by resolver
+	origProvider := provider
+	origCloud := cloudProvider
+	origExplicit := providerExplicitlyChosen
+	defer func() {
+		provider = origProvider
+		cloudProvider = origCloud
+		providerExplicitlyChosen = origExplicit
+	}()
+
+	// Force single explicit provider path that re-uses the (possibly nil) global
+	providerExplicitlyChosen = true
+	cloudProvider = "hetzner"
+	// No real client; resolver should still return one entry tagged by name
+	names := resolveProviderNames()
+	assert.Equal(t, []string{"hetzner"}, names)
+	// resolveListProviders will use the global if match and not try building
+	lps := resolveListProviders()
+	assert.Len(t, lps, 1)
+	assert.Equal(t, "hetzner", lps[0].name)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,11 @@ var (
 			case "init", "version", "help", "__complete", "__completeNoDesc":
 				return nil
 			}
+			// Capture before checkCloudProvider() (inside initState) sets
+			// ONCTL_CLOUD as a side effect when it falls back to env-var
+			// detection: `ls` uses this to decide whether to aggregate
+			// across every detected provider or stick to a single one.
+			providerExplicitlyChosen = providerFlag != "" || os.Getenv("ONCTL_CLOUD") != ""
 			if providerFlag != "" {
 				if !tools.Contains(cloudProviderList, providerFlag) {
 					return fmt.Errorf("unsupported provider %q; use one of: %s", providerFlag, strings.Join(cloudProviderList, ", "))
@@ -69,6 +74,11 @@ var (
 	cloudProviderList = []string{"aws", "hetzner", "azure", "gcp", "fc"}
 	provider          cloud.CloudProviderInterface
 	providerFlag      string
+	// providerExplicitlyChosen records whether --provider/ONCTL_CLOUD was set
+	// before provider resolution ran. `ls` uses it to decide whether to
+	// aggregate across every detected provider (see resolveListProviders in
+	// list.go) or keep today's single-provider behavior.
+	providerExplicitlyChosen bool
 )
 
 func checkCloudProvider() string {
@@ -140,9 +150,17 @@ func ensureProvider() {
 
 // initProvider builds the global provider client for the selected cloud.
 func initProvider(cloudProvider string) {
-	switch cloudProvider {
+	provider = buildProvider(cloudProvider)
+}
+
+// buildProvider constructs a provider client for the named cloud, without
+// touching the global provider/cloudProvider vars. Extracted from
+// initProvider so `ls` can build one client per auto-detected provider (see
+// resolveListProviders in list.go) alongside the normal single-provider path.
+func buildProvider(name string) cloud.CloudProviderInterface {
+	switch name {
 	case "hetzner":
-		provider = &cloud.ProviderHetzner{
+		return &cloud.ProviderHetzner{
 			Client: providerhtz.GetClient(),
 			Config: cloud.HetznerConfig{
 				Location:      viper.GetString("hetzner.location"),
@@ -153,17 +171,16 @@ func initProvider(cloudProvider string) {
 			},
 		}
 	case "gcp":
-		provider = &cloud.ProviderGcp{
+		return &cloud.ProviderGcp{
 			Client:      providergcp.GetClient(),
 			GroupClient: providergcp.GetGroupClient(),
 		}
-
 	case "aws":
-		provider = &cloud.ProviderAws{
+		return &cloud.ProviderAws{
 			Client: provideraws.GetClient(),
 		}
 	case "azure":
-		provider = &cloud.ProviderAzure{
+		return &cloud.ProviderAzure{
 			ResourceGraphClient: providerazure.GetResourceGraphClient(),
 			VmClient:            providerazure.GetVmClient(),
 			NicClient:           providerazure.GetNicClient(),
@@ -174,7 +191,7 @@ func initProvider(cloudProvider string) {
 		}
 	case "fc":
 		fcConfig := providerfc.GetConfig()
-		provider = &cloud.ProviderFC{
+		return &cloud.ProviderFC{
 			Config:  fcConfig,
 			Process: providerfc.NewProcessManager(fcConfig.BinPath),
 			API:     providerfc.NewAPIClient(),
@@ -182,6 +199,7 @@ func initProvider(cloudProvider string) {
 			Rootfs:  providerfc.NewRootfsPreparer(),
 		}
 	}
+	return nil
 }
 
 func init() {

--- a/internal/providerazure/common.go
+++ b/internal/providerazure/common.go
@@ -14,7 +14,8 @@ import (
 func GetResourceGraphClient() (resourceGraphClient *armresourcegraph.Client) {
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
 	resourceGraphClient, err = armresourcegraph.NewClient(cred, nil)
 	if err != nil {
@@ -25,11 +26,17 @@ func GetResourceGraphClient() (resourceGraphClient *armresourcegraph.Client) {
 }
 
 func GetVmClient() (vmClient *armcompute.VirtualMachinesClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	vmClient, err = armcompute.NewVirtualMachinesClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	vmClient, err = armcompute.NewVirtualMachinesClient(sub, cred, nil)
 	// armCompute, err = armcompute.
 	if err != nil {
 		return nil
@@ -39,11 +46,17 @@ func GetVmClient() (vmClient *armcompute.VirtualMachinesClient) {
 }
 
 func GetNicClient() (nicClient *armnetwork.InterfacesClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	nicClient, err = armnetwork.NewInterfacesClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	nicClient, err = armnetwork.NewInterfacesClient(sub, cred, nil)
 	if err != nil {
 		return nil
 	}
@@ -52,11 +65,17 @@ func GetNicClient() (nicClient *armnetwork.InterfacesClient) {
 }
 
 func GetSSHKeyClient() (sshClient *armcompute.SSHPublicKeysClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	sshClient, err = armcompute.NewSSHPublicKeysClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	sshClient, err = armcompute.NewSSHPublicKeysClient(sub, cred, nil)
 	if err != nil {
 		return nil
 	}
@@ -65,11 +84,17 @@ func GetSSHKeyClient() (sshClient *armcompute.SSHPublicKeysClient) {
 }
 
 func GetIPClient() (publicIpClient *armnetwork.PublicIPAddressesClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	ipClient, err := armnetwork.NewPublicIPAddressesClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	ipClient, err := armnetwork.NewPublicIPAddressesClient(sub, cred, nil)
 	if err != nil {
 		return nil
 	}
@@ -78,11 +103,17 @@ func GetIPClient() (publicIpClient *armnetwork.PublicIPAddressesClient) {
 }
 
 func GetVnetClient() (vnetClient *armnetwork.VirtualNetworksClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	vnetClient, err = armnetwork.NewVirtualNetworksClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	vnetClient, err = armnetwork.NewVirtualNetworksClient(sub, cred, nil)
 	if err != nil {
 		return nil
 	}
@@ -91,11 +122,17 @@ func GetVnetClient() (vnetClient *armnetwork.VirtualNetworksClient) {
 }
 
 func GetNSGClient() (nsgClient *armnetwork.SecurityGroupsClient) {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" {
+		log.Printf("[DEBUG] azure.subscriptionId not configured")
+		return nil
+	}
 	cred, err := connectionAzure()
 	if err != nil {
-		log.Fatalf("cannot connect to Azure:%+v", err)
+		log.Printf("[DEBUG] cannot connect to Azure: %+v", err)
+		return nil
 	}
-	nsgClient, err = armnetwork.NewSecurityGroupsClient(viper.GetString("azure.subscriptionId"), cred, nil)
+	nsgClient, err = armnetwork.NewSecurityGroupsClient(sub, cred, nil)
 	if err != nil {
 		return nil
 	}

--- a/internal/providergcp/common.go
+++ b/internal/providergcp/common.go
@@ -11,7 +11,8 @@ func GetClient() *compute.InstancesClient {
 	ctx := context.Background()
 	client, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {
-		log.Fatalln(err)
+		log.Printf("[DEBUG] failed to create gcp instances client: %v", err)
+		return nil
 	}
 	return client
 }
@@ -20,7 +21,8 @@ func GetGroupClient() *compute.InstanceGroupsClient {
 	ctx := context.Background()
 	client, err := compute.NewInstanceGroupsRESTClient(ctx)
 	if err != nil {
-		log.Fatalln(err)
+		log.Printf("[DEBUG] failed to create gcp instanceGroups client: %v", err)
+		return nil
 	}
 	return client
 }

--- a/internal/providerhtz/common.go
+++ b/internal/providerhtz/common.go
@@ -12,9 +12,7 @@ func GetClient() *hcloud.Client {
 	if token != "" {
 		client := hcloud.NewClient(hcloud.WithToken(token))
 		return client
-	} else {
-		log.Println("HCLOUD_TOKEN is not set")
-		os.Exit(1)
 	}
+	log.Printf("[DEBUG] HCLOUD_TOKEN is not set")
 	return nil
 }

--- a/internal/tools/common.go
+++ b/internal/tools/common.go
@@ -96,10 +96,17 @@ func onctlConfigDirs() []string {
 	return dirs
 }
 
+// WhichCloudProvider resolves the single provider for non-ls commands. It only
+// looks at credential env vars (matching its pre-multi-provider behavior), not
+// the yaml-presence heuristics in DetectCloudProviders: a placeholder
+// <provider>.yaml from `onctl init` should not make create/destroy/ssh/etc.
+// silently target an uncredentialed cloud instead of failing with "No Cloud
+// Provider Set".
 func WhichCloudProvider() string {
-	found := DetectCloudProviders()
-	if len(found) == 0 {
-		return "none"
+	for _, c := range providerEnvChecks {
+		if c.check() {
+			return c.name
+		}
 	}
-	return found[0]
+	return "none"
 }

--- a/internal/tools/common.go
+++ b/internal/tools/common.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func Contains(slice []string, searchValue string) bool {
@@ -13,18 +14,92 @@ func Contains(slice []string, searchValue string) bool {
 	return false
 }
 
+var providerEnvChecks = []struct {
+	name  string
+	check func() bool
+}{
+	{"aws", func() bool {
+		if os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_PROFILE") != "" {
+			return true
+		}
+		// Common AWS SDK shared config locations. Even without explicit
+		// AWS_* env vars or ONCTL_CLOUD, a populated ~/.aws/credentials
+		// (or config) means the user can auth to AWS and ls should consider it.
+		home, _ := os.UserHomeDir()
+		candidates := []string{
+			filepath.Join(home, ".aws", "credentials"),
+			filepath.Join(home, ".aws", "config"),
+			os.Getenv("AWS_SHARED_CREDENTIALS_FILE"),
+			os.Getenv("AWS_CONFIG_FILE"),
+		}
+		for _, c := range candidates {
+			if c != "" {
+				if _, err := os.Stat(c); err == nil {
+					return true
+				}
+			}
+		}
+		return false
+	}},
+	{"azure", func() bool { return os.Getenv("AZURE_CLIENT_ID") != "" }},
+	{"gcp", func() bool { return os.Getenv("GOOGLE_CREDENTIALS") != "" }},
+	{"hetzner", func() bool { return os.Getenv("HCLOUD_TOKEN") != "" }},
+}
+
+// DetectCloudProviders returns every provider that looks configured either
+// through credential env vars or by the presence of its onctl provider
+// yaml (<name>.yaml) in standard config locations. Used by `onctl ls` to
+// decide whether to query one or all clouds when no explicit --provider or
+// ONCTL_CLOUD is in effect. We deliberately keep env + fs heuristics rather
+// than attempting to actually auth at detection time (clients are built only
+// when we decide to list).
+func DetectCloudProviders() []string {
+	var found []string
+	for _, c := range providerEnvChecks {
+		if c.check() {
+			found = append(found, c.name)
+		}
+	}
+	// Also detect via onctl yaml files. This catches common flows where
+	// users ran `onctl init` for several providers (yamls always written),
+	// or azure/gcp where the yaml carries subscription/project required even
+	// if the specific env marker is absent.
+	for _, name := range []string{"aws", "hetzner", "azure", "gcp", "fc"} {
+		if hasProviderYAML(name) && !Contains(found, name) {
+			found = append(found, name)
+		}
+	}
+	return found
+}
+
+// hasProviderYAML reports whether a <name>.yaml (e.g. aws.yaml) exists in
+// any onctl config directory (cwd/.onctl or ~/.onctl).
+func hasProviderYAML(name string) bool {
+	for _, dir := range onctlConfigDirs() {
+		if _, err := os.Stat(filepath.Join(dir, name+".yaml")); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// onctlConfigDirs returns the list of directories where onctl stores provider
+// yamls (searched in the same order as ReadConfig).
+func onctlConfigDirs() []string {
+	var dirs []string
+	if cwd, err := os.Getwd(); err == nil {
+		dirs = append(dirs, filepath.Join(cwd, ".onctl"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".onctl"))
+	}
+	return dirs
+}
+
 func WhichCloudProvider() string {
-	if os.Getenv("AWS_ACCESS_KEY_ID") != "" || os.Getenv("AWS_PROFILE") != "" {
-		return "aws"
+	found := DetectCloudProviders()
+	if len(found) == 0 {
+		return "none"
 	}
-	if os.Getenv("AZURE_CLIENT_ID") != "" {
-		return "azure"
-	}
-	if os.Getenv("GOOGLE_CREDENTIALS") != "" {
-		return "gcp"
-	}
-	if os.Getenv("HCLOUD_TOKEN") != "" {
-		return "hetzner"
-	}
-	return "none"
+	return found[0]
 }

--- a/internal/tools/common_test.go
+++ b/internal/tools/common_test.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,6 +31,15 @@ func TestContains(t *testing.T) {
 }
 
 func TestWhichCloudProvider(t *testing.T) {
+	// Isolate from any real onctl home or cwd yamls so file-based detection is off.
+	// We set HOME to a clean dir and chdir to an empty cwd.
+	cleanHome := t.TempDir()
+	t.Setenv("HOME", cleanHome)
+	origDir, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
 	// Clear all cloud provider env vars first
 	envVars := []string{
 		"AWS_ACCESS_KEY_ID", "AWS_PROFILE",
@@ -76,5 +86,53 @@ func TestWhichCloudProvider(t *testing.T) {
 		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
 		result := WhichCloudProvider()
 		assert.Equal(t, "hetzner", result)
+	})
+}
+
+func TestDetectCloudProviders(t *testing.T) {
+	// Isolate from real onctl config dirs. Point $HOME at temp + clean cwd.
+	cleanHome := t.TempDir()
+	t.Setenv("HOME", cleanHome)
+	origDir, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
+	envVars := []string{
+		"AWS_ACCESS_KEY_ID", "AWS_PROFILE",
+		"AZURE_CLIENT_ID", "GOOGLE_CREDENTIALS", "HCLOUD_TOKEN",
+	}
+	for _, v := range envVars {
+		require.NoError(t, os.Unsetenv(v))
+	}
+
+	t.Run("none set", func(t *testing.T) {
+		assert.Empty(t, DetectCloudProviders())
+	})
+
+	t.Run("one set", func(t *testing.T) {
+		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
+		assert.Equal(t, []string{"hetzner"}, DetectCloudProviders())
+	})
+
+	t.Run("multiple set, returned in priority order", func(t *testing.T) {
+		t.Setenv("HCLOUD_TOKEN", "some-hcloud-token")
+		t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+		assert.Equal(t, []string{"aws", "hetzner"}, DetectCloudProviders())
+	})
+
+	t.Run("detected from onctl yaml even without cred env", func(t *testing.T) {
+		// Use the isolated HOME's .onctl (we set HOME to cleanHome above).
+		onctlDir := filepath.Join(cleanHome, ".onctl")
+		require.NoError(t, os.MkdirAll(onctlDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(onctlDir, "aws.yaml"), []byte("aws:\n  vm:\n    username: ubuntu\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(onctlDir, "hetzner.yaml"), []byte("hetzner:\n  vm:\n    username: root\n"), 0o644))
+		// ensure no cred envs interfere
+		for _, v := range []string{"AWS_ACCESS_KEY_ID", "AWS_PROFILE", "HCLOUD_TOKEN", "AZURE_CLIENT_ID", "GOOGLE_CREDENTIALS"} {
+			require.NoError(t, os.Unsetenv(v))
+		}
+		got := DetectCloudProviders()
+		// append order is aws then hetzner for the hardcoded yaml scan list
+		assert.Equal(t, []string{"aws", "hetzner"}, got)
 	})
 }

--- a/internal/tools/common_test.go
+++ b/internal/tools/common_test.go
@@ -37,8 +37,8 @@ func TestWhichCloudProvider(t *testing.T) {
 	t.Setenv("HOME", cleanHome)
 	origDir, _ := os.Getwd()
 	tmp := t.TempDir()
-	os.Chdir(tmp)
-	defer os.Chdir(origDir)
+	require.NoError(t, os.Chdir(tmp))
+	defer func() { require.NoError(t, os.Chdir(origDir)) }()
 
 	// Clear all cloud provider env vars first
 	envVars := []string{
@@ -95,8 +95,8 @@ func TestDetectCloudProviders(t *testing.T) {
 	t.Setenv("HOME", cleanHome)
 	origDir, _ := os.Getwd()
 	tmp := t.TempDir()
-	os.Chdir(tmp)
-	defer os.Chdir(origDir)
+	require.NoError(t, os.Chdir(tmp))
+	defer func() { require.NoError(t, os.Chdir(origDir)) }()
 
 	envVars := []string{
 		"AWS_ACCESS_KEY_ID", "AWS_PROFILE",

--- a/pkg/cloud/aws.go
+++ b/pkg/cloud/aws.go
@@ -316,6 +316,9 @@ func (p ProviderAws) ListPaused() (VmList, error) {
 }
 
 func (p ProviderAws) List() (VmList, error) {
+	if p.Client == nil {
+		return VmList{}, fmt.Errorf("aws client not configured")
+	}
 
 	input := &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{

--- a/pkg/cloud/azure.go
+++ b/pkg/cloud/azure.go
@@ -42,6 +42,9 @@ func (p ProviderAzure) ListPaused() (VmList, error) {
 
 func (p ProviderAzure) List() (VmList, error) {
 	log.Println("[DEBUG] List Servers")
+	if p.ResourceGraphClient == nil {
+		return VmList{}, fmt.Errorf("azure client not configured (missing subscriptionId or credentials)")
+	}
 	query := `
 	resources
     | where type =~ 'microsoft.compute/virtualmachines' and resourceGroup =~ '` + viper.GetString("azure.resourceGroup") + `'	
@@ -79,12 +82,11 @@ func (p ProviderAzure) List() (VmList, error) {
 		},
 		nil)
 	if err != nil {
-		log.Fatalf("failed to finish the request: %v", err)
-	} else {
-		// Print the obtained query results
-		log.Printf("[DEBUG] Resources found: %d\n", *resp.TotalRecords)
-		log.Printf("[DEBUG] Results: %v\n", resp.Data)
+		return VmList{}, fmt.Errorf("azure resource graph query failed: %w", err)
 	}
+	// Print the obtained query results
+	log.Printf("[DEBUG] Resources found: %d\n", *resp.TotalRecords)
+	log.Printf("[DEBUG] Results: %v\n", resp.Data)
 	if len(strconv.FormatInt(*resp.TotalRecords, 10)) == 0 {
 		return VmList{}, nil
 	}
@@ -95,7 +97,7 @@ func (p ProviderAzure) List() (VmList, error) {
 			items := r.(map[string]interface{})
 			createdAt, err := time.Parse("2006-01-02T15:04:05Z", items["timeCreated"].(string))
 			if err != nil {
-				log.Fatalln(err)
+				return VmList{}, fmt.Errorf("failed to parse azure timeCreated: %w", err)
 			}
 			if items["publicIpAddress"] == nil {
 				items["publicIpAddress"] = "N/A"

--- a/pkg/cloud/gcp.go
+++ b/pkg/cloud/gcp.go
@@ -33,6 +33,9 @@ func (p ProviderGcp) ListPaused() (VmList, error) {
 
 func (p ProviderGcp) List() (VmList, error) {
 	log.Println("[DEBUG] List Servers")
+	if p.Client == nil {
+		return VmList{}, fmt.Errorf("gcp client not configured (missing credentials)")
+	}
 	cloudList := make([]Vm, 0, 100)
 	it := p.Client.AggregatedList(context.Background(), &computepb.AggregatedListInstancesRequest{
 		Project: viper.GetString("gcp.project"),
@@ -43,7 +46,7 @@ func (p ProviderGcp) List() (VmList, error) {
 			break
 		}
 		if err != nil {
-			log.Fatalln(err)
+			return VmList{}, fmt.Errorf("gcp aggregated list error: %w", err)
 		}
 		for _, instance := range resp.Value.Instances {
 			cloudList = append(cloudList, mapGcpServer(instance))
@@ -222,7 +225,8 @@ func (p ProviderGcp) SSHInto(serverName string, port int, privateKey string, com
 func mapGcpServer(server *computepb.Instance) Vm {
 	createdAt, err := time.Parse(time.RFC3339, *server.CreationTimestamp)
 	if err != nil {
-		log.Fatalln(err)
+		log.Printf("[DEBUG] gcp bad CreationTimestamp: %v", err)
+		createdAt = time.Time{}
 	}
 
 	return Vm{

--- a/pkg/cloud/hetzner.go
+++ b/pkg/cloud/hetzner.go
@@ -363,6 +363,9 @@ func (p ProviderHetzner) findReservedPrimaryIPs(name string) []*hcloud.PrimaryIP
 // snapshots. The preserved primary IPv4 (tagged at pause time) is shown so the
 // user sees the address that will return on Resume.
 func (p ProviderHetzner) ListPaused() (VmList, error) {
+	if p.Client == nil {
+		return VmList{}, fmt.Errorf("hetzner client not configured (missing HCLOUD_TOKEN)")
+	}
 	images, err := p.Client.Image.AllWithOpts(context.TODO(), hcloud.ImageListOpts{
 		Type:     []hcloud.ImageType{hcloud.ImageTypeSnapshot},
 		ListOpts: hcloud.ListOpts{LabelSelector: labelOwner + "=onctl"},
@@ -423,6 +426,9 @@ func (p ProviderHetzner) ListPaused() (VmList, error) {
 
 func (p ProviderHetzner) List() (VmList, error) {
 	log.Println("[DEBUG] List Servers")
+	if p.Client == nil {
+		return VmList{}, fmt.Errorf("hetzner client not configured (missing HCLOUD_TOKEN)")
+	}
 	list, _, err := p.Client.Server.List(context.TODO(), hcloud.ServerListOpts{
 		ListOpts: hcloud.ListOpts{
 			LabelSelector: "Owner=onctl",


### PR DESCRIPTION
## Summary

Adds support for `onctl ls` (alias `list`) to query **all** configured providers and combine  their VMs when `--provider` / `ONCTL_CLOUD` is not explicitly set. Explicit choice of a single provider keeps the previous single-provider behaviour.

## Changes

* Widened `DetectCloudProviders()` (internal/tools) to also recognise:
  - `~/.aws/{credentials,config}` (and related env vars)
  - presence of `<provider>.yaml` files in the standard `.onctl/` locations
* New helpers in `cmd/list.go`:
  - `resolveProviderNames()`
  - `resolveListProviders()`
  - `namedProvider` (carries the provider name with the client for correct username lookup, cost handling, etc.)
* `buildProvider(name)` extracted (root.go) so it can be called for multiple providers without mutating the global.
* Best-effort `ReadConfig(name)` for each secondary provider so per-provider settings (e.g. azure.subscriptionId, gcp.project) are present.
* Provider implementations made tolerant for the ls use case:
  - Azure, GCP, Hetzner client constructors no longer fatal
  - `List` / `ListPaused` now return errors instead of `log.Fatal`
* Per-provider errors are only printed at `[DEBUG]` level so a single misconfigured cloud does not ruin the output.
* Single-provider behaviour (Hetzner costs, separate PAUSED/RUNNING tables, Ansible `ansible_user` via server.Provider, etc.) preserved.
* Test updates + new cases for yaml-driven detection and provider resolution.

## Technical notes

The decision "aggregate vs single" is taken early using a pre-detection flag (`providerExplicitlyChosen`). When multiple providers are chosen the code calls `List()` / `ListPaused()` on each built client, concatenates the results and renders the (tagged) table(s) once.

## Verification performed

- `make` (fmt + build)
- `go test ./internal/tools ./cmd -run "Detect|Which|Resolve|List"`
- Manual runs with multiple configured clouds (both yamls present on disk + mixed real credentials):
  ```
  ONCTL_CLOUD= ./onctl ls
  ```
  Produces a single combined RUNNING / PAUSED table containing rows from every reachable provider.

## Related

Continuation of the work started on the `feat/ls-multi-provider` branch.