### PR TITLE
Add scripts/install-dev.sh for onctl-dev install/update

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Installs or updates onctl-dev (onctl built from the main branch) via Homebrew.
+set -euo pipefail
+
+brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev


### PR DESCRIPTION
## Summary
- Adds `scripts/install-dev.sh`, a one-command wrapper for installing/updating `onctl-dev` (the `onctl-dev` Homebrew formula added in cdalar/homebrew-tap#2, which builds `onctl` from `main`).
- Avoids needing to remember `brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev` — the same command handles both first install and pulling newer `main` commits.

## Test plan
- [x] Ran the script locally; confirmed it correctly reports `onctl-dev` is already up to date when `main` hasn't changed
- [x] Verified `--HEAD --fetch-HEAD` is the correct combined flag for install-or-update-to-latest-HEAD semantics