### PR TITLE
docs(readme): mention onctl-dev for installing latest main build

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ root@onctl-test:~#
 brew install cdalar/tap/onctl
 ```
 
+#### Dev build (latest `main`)
+
+To install or update `onctl-dev`, a build of the latest `main` branch (installed alongside the regular `onctl`):
+
+```zsh
+./scripts/install-dev.sh
+```
+
+Or directly via Homebrew:
+
+```zsh
+brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev
+```
+
 ### Linux
 
 ```bash


### PR DESCRIPTION
## Summary
- Documents `onctl-dev` (added in #931) under the macOS install section of the README, pointing to `scripts/install-dev.sh` and the equivalent raw `brew` command.

## Test plan
- [x] Rendered README locally to confirm formatting