### PR TITLE
feat: complete single onctl.yaml migration for GCP and Azure (CLI flags + resolve)

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -47,6 +47,10 @@ var (
 	flagFCBinary      string
 	flagFCVCPU        int64
 	flagFCMemory      int64
+	// GCP-specific flag bound to gcp.project (see init below). This replaces
+	// the placeholder in onctl.yaml's gcp.project (the one GCP setting with
+	// no static default; it's account-specific).
+	flagGCPProject string
 )
 
 func parseConfigFile(configFile string) (*cmdCreateOptions, error) {
@@ -105,6 +109,16 @@ func init() {
 	_ = viper.BindPFlag("aws.location", createCmd.Flags().Lookup("location"))
 	_ = viper.BindPFlag("aws.vm.username", createCmd.Flags().Lookup("username"))
 	_ = viper.BindPFlag("aws.vm.image", createCmd.Flags().Lookup("image"))
+
+	// GCP. Same generic flags, bound to the gcp.* keys read by pkg/cloud/gcp.go.
+	// gcp.project has the placeholder in onctl.yaml; --project + resolveGCPProject
+	// in root.go provide the fallback to `gcloud config`. --type/--location/--username
+	// work the same as for other providers.
+	createCmd.Flags().StringVar(&flagGCPProject, "project", "", "GCP: project ID (falls back to `gcloud config get-value project` when the onctl.yaml placeholder is present)")
+	_ = viper.BindPFlag("gcp.project", createCmd.Flags().Lookup("project"))
+	_ = viper.BindPFlag("gcp.zone", createCmd.Flags().Lookup("location"))
+	_ = viper.BindPFlag("gcp.type", createCmd.Flags().Lookup("type"))
+	_ = viper.BindPFlag("gcp.vm.username", createCmd.Flags().Lookup("username"))
 
 	// Firecracker-specific flags, each bound to the fc.* key read by
 	// providerfc.GetConfig. Defaults live in onctl.yaml's fc: section (and

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -91,11 +91,6 @@ func init() {
 	createCmd.Flags().StringVarP(&opt.ConfigFile, "file", "f", "", "Path to configuration YAML file")
 	createCmd.Flags().StringVar(&opt.Vm.Image, "image", "", "OS image to use (e.g. ubuntu-22.04, fedora-42)")
 
-	// Register Azure special flags locally too (root registers them as persistent
-	// for ls/destroy etc). This makes Lookup work and shows them under create --help.
-	createCmd.Flags().StringVar(&flagAzureSubscriptionID, "subscription-id", "", "Azure: subscription ID (required for the azure provider; falls back to `az account show`)")
-	createCmd.Flags().StringVar(&flagAzureResourceGroup, "resource-group", "", "Azure: resource group (required for the azure provider; falls back to the az CLI's configured default group, if any)")
-
 	// Generic VM flags, bound to the viper key the rest of the code already
 	// reads. The hetzner.* defaults live in internal/files/init/onctl.yaml,
 	// written by `onctl init`; these flag defaults only act as a last-resort
@@ -119,22 +114,15 @@ func init() {
 	_ = viper.BindPFlag("aws.vm.username", createCmd.Flags().Lookup("username"))
 	_ = viper.BindPFlag("aws.vm.image", createCmd.Flags().Lookup("image"))
 
-	// GCP. Same generic flags, bound to the gcp.* keys read by pkg/cloud/gcp.go.
-	// gcp.project has the placeholder in onctl.yaml; --project + resolveGCPProject
-	// in root.go provide the fallback to `gcloud config`. --type/--location/--username
-	// work the same as for other providers.
-	createCmd.Flags().StringVar(&flagGCPProject, "project", "", "GCP: project ID (falls back to `gcloud config get-value project` when the onctl.yaml placeholder is present)")
-	_ = viper.BindPFlag("gcp.project", createCmd.Flags().Lookup("project"))
+	// GCP. Bind the shared generic flags to gcp.* (gcp.project is bound as
+	// a root persistent flag so it is available to ls/ssh/destroy etc.).
+	// --type/--location/--username work the same as for other providers.
 	_ = viper.BindPFlag("gcp.zone", createCmd.Flags().Lookup("location"))
 	_ = viper.BindPFlag("gcp.type", createCmd.Flags().Lookup("type"))
 	_ = viper.BindPFlag("gcp.vm.username", createCmd.Flags().Lookup("username"))
 
-	// Azure. Bind generics + the two account-specific ones.
-	// subscriptionId and resourceGroup have no static defaults (placeholders
-	// in onctl.yaml); --subscription-id / --resource-group + resolve fill them.
-	// Use root persistent lookups because those flags are registered as persistent.
-	_ = viper.BindPFlag("azure.subscriptionId", rootCmd.PersistentFlags().Lookup("subscription-id"))
-	_ = viper.BindPFlag("azure.resourceGroup", rootCmd.PersistentFlags().Lookup("resource-group"))
+	// Azure. Bind the shared generic flags (account-specific ones are bound
+	// as root persistent flags for availability outside create).
 	_ = viper.BindPFlag("azure.location", createCmd.Flags().Lookup("location"))
 	_ = viper.BindPFlag("azure.vm.type", createCmd.Flags().Lookup("type"))
 	_ = viper.BindPFlag("azure.vm.username", createCmd.Flags().Lookup("username"))

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -51,6 +51,10 @@ var (
 	// the placeholder in onctl.yaml's gcp.project (the one GCP setting with
 	// no static default; it's account-specific).
 	flagGCPProject string
+	// Azure account-specific flags (moved to persistent in root so resolve
+	// works for ls/destroy/ssh too, not just create). Bound to azure.* .
+	flagAzureSubscriptionID string
+	flagAzureResourceGroup  string
 )
 
 func parseConfigFile(configFile string) (*cmdCreateOptions, error) {
@@ -87,6 +91,11 @@ func init() {
 	createCmd.Flags().StringVarP(&opt.ConfigFile, "file", "f", "", "Path to configuration YAML file")
 	createCmd.Flags().StringVar(&opt.Vm.Image, "image", "", "OS image to use (e.g. ubuntu-22.04, fedora-42)")
 
+	// Register Azure special flags locally too (root registers them as persistent
+	// for ls/destroy etc). This makes Lookup work and shows them under create --help.
+	createCmd.Flags().StringVar(&flagAzureSubscriptionID, "subscription-id", "", "Azure: subscription ID (required for the azure provider; falls back to `az account show`)")
+	createCmd.Flags().StringVar(&flagAzureResourceGroup, "resource-group", "", "Azure: resource group (required for the azure provider; falls back to the az CLI's configured default group, if any)")
+
 	// Generic VM flags, bound to the viper key the rest of the code already
 	// reads. The hetzner.* defaults live in internal/files/init/onctl.yaml,
 	// written by `onctl init`; these flag defaults only act as a last-resort
@@ -119,6 +128,16 @@ func init() {
 	_ = viper.BindPFlag("gcp.zone", createCmd.Flags().Lookup("location"))
 	_ = viper.BindPFlag("gcp.type", createCmd.Flags().Lookup("type"))
 	_ = viper.BindPFlag("gcp.vm.username", createCmd.Flags().Lookup("username"))
+
+	// Azure. Bind generics + the two account-specific ones.
+	// subscriptionId and resourceGroup have no static defaults (placeholders
+	// in onctl.yaml); --subscription-id / --resource-group + resolve fill them.
+	// Use root persistent lookups because those flags are registered as persistent.
+	_ = viper.BindPFlag("azure.subscriptionId", rootCmd.PersistentFlags().Lookup("subscription-id"))
+	_ = viper.BindPFlag("azure.resourceGroup", rootCmd.PersistentFlags().Lookup("resource-group"))
+	_ = viper.BindPFlag("azure.location", createCmd.Flags().Lookup("location"))
+	_ = viper.BindPFlag("azure.vm.type", createCmd.Flags().Lookup("type"))
+	_ = viper.BindPFlag("azure.vm.username", createCmd.Flags().Lookup("username"))
 
 	// Firecracker-specific flags, each bound to the fc.* key read by
 	// providerfc.GetConfig. Defaults live in onctl.yaml's fc: section (and

--- a/cmd/flags_defaults_test.go
+++ b/cmd/flags_defaults_test.go
@@ -13,7 +13,7 @@ import (
 // TestGenericCreateFlagsExist verifies the YAML-replacing flags are registered.
 func TestGenericCreateFlagsExist(t *testing.T) {
 	for _, name := range []string{"type", "location", "username", "cloud-init-timeout", "image",
-		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory"} {
+		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory", "project"} {
 		assert.NotNil(t, createCmd.Flags().Lookup(name), "create should have --%s flag", name)
 	}
 	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("provider"), "root should have persistent --provider flag")
@@ -60,6 +60,10 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		{"type", "aws.vm.type", "t2.micro", "m5.large"},
 		{"location", "aws.location", "eu-central-1", "us-east-1"},
 		{"username", "aws.vm.username", "ubuntu", "ec2-user"},
+		// GCP (from onctl.yaml gcp: section; project is account-specific placeholder
+		// resolved via gcloud or --project; tested separately).
+		{"type", "gcp.type", "n1-standard-1", "n2-standard-2"},
+		{"location", "gcp.zone", "europe-west4-a", "us-central1-a"},
 	}
 	// Check every default before mutating any flag. Several keys share a
 	// flag with a different per-provider default (e.g. --type backs both
@@ -72,6 +76,7 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		assert.Equal(t, c.def, viper.GetString(c.key), "default for %s", c.key)
 	}
 	assert.Equal(t, "root", viper.GetString("fc.vm.username"))
+	assert.Equal(t, "root", viper.GetString("gcp.vm.username"))
 
 	for _, c := range cases {
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.override))
@@ -79,10 +84,10 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.def))
 	}
 
-	// The generic --username flag drives the Firecracker and AWS users too.
+	// The generic --username flag drives the Firecracker and GCP users too.
 	assert.NoError(t, createCmd.Flags().Set("username", "admin"))
 	assert.Equal(t, "admin", viper.GetString("fc.vm.username"))
-	assert.Equal(t, "admin", viper.GetString("aws.vm.username"))
+	assert.Equal(t, "admin", viper.GetString("gcp.vm.username"))
 
 	// Restore the shared flags to their own intrinsic defaults (not
 	// whichever per-provider case happened to run last) so sibling tests in

--- a/cmd/flags_defaults_test.go
+++ b/cmd/flags_defaults_test.go
@@ -13,7 +13,8 @@ import (
 // TestGenericCreateFlagsExist verifies the YAML-replacing flags are registered.
 func TestGenericCreateFlagsExist(t *testing.T) {
 	for _, name := range []string{"type", "location", "username", "cloud-init-timeout", "image",
-		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory", "project"} {
+		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory", "project",
+		"subscription-id", "resource-group"} {
 		assert.NotNil(t, createCmd.Flags().Lookup(name), "create should have --%s flag", name)
 	}
 	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("provider"), "root should have persistent --provider flag")
@@ -64,6 +65,10 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		// resolved via gcloud or --project; tested separately).
 		{"type", "gcp.type", "n1-standard-1", "n2-standard-2"},
 		{"location", "gcp.zone", "europe-west4-a", "us-central1-a"},
+		// Azure (from onctl.yaml azure: section).
+		{"type", "azure.vm.type", "Standard_D4s_v3", "Standard_D8s_v3"},
+		{"location", "azure.location", "westeurope", "northeurope"},
+		{"username", "azure.vm.username", "azureuser", "adminuser"},
 	}
 	// Check every default before mutating any flag. Several keys share a
 	// flag with a different per-provider default (e.g. --type backs both
@@ -77,6 +82,7 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 	}
 	assert.Equal(t, "root", viper.GetString("fc.vm.username"))
 	assert.Equal(t, "root", viper.GetString("gcp.vm.username"))
+	assert.Equal(t, "azureuser", viper.GetString("azure.vm.username"))
 
 	for _, c := range cases {
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.override))
@@ -84,10 +90,11 @@ func TestCreateFlagsBindToViper(t *testing.T) {
 		assert.NoError(t, createCmd.Flags().Set(c.flag, c.def))
 	}
 
-	// The generic --username flag drives the Firecracker and GCP users too.
+	// The generic --username flag drives the Firecracker , GCP and Azure users too.
 	assert.NoError(t, createCmd.Flags().Set("username", "admin"))
 	assert.Equal(t, "admin", viper.GetString("fc.vm.username"))
 	assert.Equal(t, "admin", viper.GetString("gcp.vm.username"))
+	assert.Equal(t, "admin", viper.GetString("azure.vm.username"))
 
 	// Restore the shared flags to their own intrinsic defaults (not
 	// whichever per-provider case happened to run last) so sibling tests in

--- a/cmd/flags_defaults_test.go
+++ b/cmd/flags_defaults_test.go
@@ -13,9 +13,13 @@ import (
 // TestGenericCreateFlagsExist verifies the YAML-replacing flags are registered.
 func TestGenericCreateFlagsExist(t *testing.T) {
 	for _, name := range []string{"type", "location", "username", "cloud-init-timeout", "image",
-		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory", "project",
-		"subscription-id", "resource-group"} {
+		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory"} {
 		assert.NotNil(t, createCmd.Flags().Lookup(name), "create should have --%s flag", name)
+	}
+	// project, subscription-id, and resource-group are registered as root
+	// persistent flags (not create-local) so ls/ssh/destroy can use them too.
+	for _, name := range []string{"project", "subscription-id", "resource-group"} {
+		assert.NotNil(t, rootCmd.PersistentFlags().Lookup(name), "root should have persistent --%s flag", name)
 	}
 	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("provider"), "root should have persistent --provider flag")
 	assert.NotNil(t, actionCmd.Flags().Lookup("github-owner"), "action should have --github-owner flag")

--- a/cmd/flags_defaults_test.go
+++ b/cmd/flags_defaults_test.go
@@ -11,15 +11,17 @@ import (
 )
 
 // TestGenericCreateFlagsExist verifies the YAML-replacing flags are registered.
+// Some flags (project, subscription-id, resource-group) are registered as root
+// persistent flags (so that non-create commands like ls can use them) but must
+// still be available for the create command.
 func TestGenericCreateFlagsExist(t *testing.T) {
 	for _, name := range []string{"type", "location", "username", "cloud-init-timeout", "image",
-		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory"} {
-		assert.NotNil(t, createCmd.Flags().Lookup(name), "create should have --%s flag", name)
-	}
-	// project, subscription-id, and resource-group are registered as root
-	// persistent flags (not create-local) so ls/ssh/destroy can use them too.
-	for _, name := range []string{"project", "subscription-id", "resource-group"} {
-		assert.NotNil(t, rootCmd.PersistentFlags().Lookup(name), "root should have persistent --%s flag", name)
+		"kernel-image", "rootfs-image", "fc-binary", "vcpu", "memory", "project", "subscription-id", "resource-group"} {
+		f := createCmd.Flags().Lookup(name)
+		if f == nil {
+			f = rootCmd.PersistentFlags().Lookup(name)
+		}
+		assert.NotNil(t, f, "create should have --%s flag", name)
 	}
 	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("provider"), "root should have persistent --provider flag")
 	assert.NotNil(t, actionCmd.Flags().Lookup("github-owner"), "action should have --github-owner flag")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,7 +160,7 @@ func resolveAzureIdentifiers() error {
 	}
 
 	rg := viper.GetString("azure.resourceGroup")
-	if rg == "" || rg == "test" {  // "test" is the placeholder/default in onctl.yaml
+	if rg == "" || rg == "test" { // "test" is the placeholder/default in onctl.yaml
 		if group := providerazure.AzureCLIDefaultResourceGroup(); group != "" {
 			viper.Set("azure.resourceGroup", group)
 			log.Printf("[DEBUG] resolved azure.resourceGroup from az: %s", group)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,14 +103,40 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
-// initState resolves the cloud provider and loads its config. Defaults for
-// every provider live in the onctl.yaml written by `onctl init` (see
-// internal/files/init/onctl.yaml), so a missing or unreadable config is a
-// fatal error here.
+// initState resolves the cloud provider and loads its config. The onctl.yaml
+// written by `onctl init` is the source of truth (see internal/files/init/onctl.yaml).
+// A missing file is fatal. For gcp (and later azure) we additionally resolve
+// account-specific placeholders using the cloud CLIs after loading.
 func initState() error {
 	cloudProvider = checkCloudProvider()
 	log.Println("[DEBUG] Cloud: " + cloudProvider)
-	return ReadConfig()
+	if err := ReadConfig(); err != nil {
+		return err
+	}
+	if cloudProvider == "gcp" {
+		if err := resolveGCPProject(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveGCPProject fills gcp.project from the gcloud CLI's active project
+// when the value loaded from onctl.yaml is still the placeholder
+// ("<project-id>") or empty. This keeps the single onctl.yaml usable out of
+// the box for users who have gcloud configured. If still unset it returns a
+// clear actionable error.
+func resolveGCPProject() error {
+	proj := viper.GetString("gcp.project")
+	if proj != "" && proj != "<project-id>" {
+		return nil
+	}
+	if project := providergcp.GCloudDefaultProject(); project != "" {
+		viper.Set("gcp.project", project)
+		log.Printf("[DEBUG] resolved gcp.project from gcloud: %s", project)
+		return nil
+	}
+	return fmt.Errorf(`gcp.project is required: set --project, edit .onctl/onctl.yaml, or run "gcloud config set project <id>"`)
 }
 
 // ensureProvider builds the provider client if it hasn't been already.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -160,12 +160,13 @@ func resolveAzureIdentifiers() error {
 	}
 
 	rg := viper.GetString("azure.resourceGroup")
-	if rg == "" || rg == "test" { // "test" is the placeholder/default in onctl.yaml
+	if rg == "" {
+		// Only fill from az default if no value was provided in onctl.yaml
+		// (respect an explicit "test" or other name the user may have set).
 		if group := providerazure.AzureCLIDefaultResourceGroup(); group != "" {
 			viper.Set("azure.resourceGroup", group)
 			log.Printf("[DEBUG] resolved azure.resourceGroup from az: %s", group)
 		}
-		// If still empty it's ok for some users; the provider will error later if needed.
 	}
 	return nil
 }
@@ -235,11 +236,19 @@ func initProvider(cloudProvider string) {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&providerFlag, "provider", "p", "", "cloud provider: "+strings.Join(cloudProviderList, ", ")+" (overrides ONCTL_CLOUD)")
-	// Azure account-specific settings are needed for many commands (ls, ssh,
-	// destroy...), not just create. Register as persistent so resolve runs
-	// and flags are available everywhere for the azure provider.
+	// GCP project and Azure account-specific settings are needed for many
+	// commands (ls, ssh, destroy...), not just create. Register as persistent
+	// so resolve runs and flags are available everywhere.
+	rootCmd.PersistentFlags().StringVar(&flagGCPProject, "project", "", "GCP: project ID (falls back to `gcloud config get-value project` when the onctl.yaml placeholder is present)")
 	rootCmd.PersistentFlags().StringVar(&flagAzureSubscriptionID, "subscription-id", "", "Azure: subscription ID (required for the azure provider; falls back to `az account show`)")
 	rootCmd.PersistentFlags().StringVar(&flagAzureResourceGroup, "resource-group", "", "Azure: resource group (required for the azure provider; falls back to the az CLI's configured default group, if any)")
+
+	// Bind the account-specific global flags early (persistent on root) so
+	// viper sees the CLI values in initState/resolve for all commands.
+	_ = viper.BindPFlag("gcp.project", rootCmd.PersistentFlags().Lookup("project"))
+	_ = viper.BindPFlag("azure.subscriptionId", rootCmd.PersistentFlags().Lookup("subscription-id"))
+	_ = viper.BindPFlag("azure.resourceGroup", rootCmd.PersistentFlags().Lookup("resource-group"))
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,6 +118,11 @@ func initState() error {
 			return err
 		}
 	}
+	if cloudProvider == "azure" {
+		if err := resolveAzureIdentifiers(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -137,6 +142,32 @@ func resolveGCPProject() error {
 		return nil
 	}
 	return fmt.Errorf(`gcp.project is required: set --project, edit .onctl/onctl.yaml, or run "gcloud config set project <id>"`)
+}
+
+// resolveAzureIdentifiers fills azure.subscriptionId and azure.resourceGroup
+// from az CLI when the onctl.yaml still has the placeholders. Both are
+// required to talk to Azure; the resource group one may legitimately stay
+// empty for users who always pass it or set it in az defaults.
+func resolveAzureIdentifiers() error {
+	sub := viper.GetString("azure.subscriptionId")
+	if sub == "" || sub == "<subscription-id>" {
+		if id := providerazure.AzureCLISubscriptionID(); id != "" {
+			viper.Set("azure.subscriptionId", id)
+			log.Printf("[DEBUG] resolved azure.subscriptionId from az: %s", id)
+		} else {
+			return fmt.Errorf(`azure.subscriptionId is required: set --subscription-id, edit .onctl/onctl.yaml, or run "az login"`)
+		}
+	}
+
+	rg := viper.GetString("azure.resourceGroup")
+	if rg == "" || rg == "test" {  // "test" is the placeholder/default in onctl.yaml
+		if group := providerazure.AzureCLIDefaultResourceGroup(); group != "" {
+			viper.Set("azure.resourceGroup", group)
+			log.Printf("[DEBUG] resolved azure.resourceGroup from az: %s", group)
+		}
+		// If still empty it's ok for some users; the provider will error later if needed.
+	}
+	return nil
 }
 
 // ensureProvider builds the provider client if it hasn't been already.
@@ -204,6 +235,11 @@ func initProvider(cloudProvider string) {
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&providerFlag, "provider", "p", "", "cloud provider: "+strings.Join(cloudProviderList, ", ")+" (overrides ONCTL_CLOUD)")
+	// Azure account-specific settings are needed for many commands (ls, ssh,
+	// destroy...), not just create. Register as persistent so resolve runs
+	// and flags are available everywhere for the azure provider.
+	rootCmd.PersistentFlags().StringVar(&flagAzureSubscriptionID, "subscription-id", "", "Azure: subscription ID (required for the azure provider; falls back to `az account show`)")
+	rootCmd.PersistentFlags().StringVar(&flagAzureResourceGroup, "resource-group", "", "Azure: resource group (required for the azure provider; falls back to the az CLI's configured default group, if any)")
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -87,3 +87,21 @@ func TestResolveGCPProject(t *testing.T) {
 		assert.Contains(t, err.Error(), "gcp.project is required")
 	})
 }
+
+func TestResolveAzureIdentifiers(t *testing.T) {
+	origSub := viper.GetString("azure.subscriptionId")
+	origRG := viper.GetString("azure.resourceGroup")
+	defer func() {
+		viper.Set("azure.subscriptionId", origSub)
+		viper.Set("azure.resourceGroup", origRG)
+	}()
+
+	t.Run("subscription placeholder without az errors clearly", func(t *testing.T) {
+		viper.Set("azure.subscriptionId", "<subscription-id>")
+		viper.Set("azure.resourceGroup", "test")
+		t.Setenv("PATH", "") // no az
+		err := resolveAzureIdentifiers()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "azure.subscriptionId is required")
+	})
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,4 +66,24 @@ func TestExecute_Function(t *testing.T) {
 	// We can't actually call it in tests as it would try to read config files
 	// but we can verify it's properly declared
 	assert.NotNil(t, Execute)
+}
+
+func TestResolveGCPProject(t *testing.T) {
+	original := viper.GetString("gcp.project")
+	defer viper.Set("gcp.project", original)
+
+	t.Run("already set to real value", func(t *testing.T) {
+		viper.Set("gcp.project", "my-real-project")
+		assert.NoError(t, resolveGCPProject())
+		assert.Equal(t, "my-real-project", viper.GetString("gcp.project"))
+	})
+
+	t.Run("placeholder is filled from gcloud if available or errors clearly", func(t *testing.T) {
+		viper.Set("gcp.project", "<project-id>")
+		// Force no gcloud by clearing PATH for the lookup
+		t.Setenv("PATH", "")
+		err := resolveGCPProject()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "gcp.project is required")
+	})
 }

--- a/internal/providerazure/common.go
+++ b/internal/providerazure/common.go
@@ -1,7 +1,11 @@
 package providerazure
 
 import (
+	"context"
 	"log"
+	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -109,4 +113,36 @@ func connectionAzure() (azcore.TokenCredential, error) {
 		return nil, err
 	}
 	return cred, nil
+}
+
+func runAzCLI(args ...string) string {
+	if _, err := exec.LookPath("az"); err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "az", args...).Output()
+	if err != nil {
+		return ""
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" || value == "null" {
+		return ""
+	}
+	return value
+}
+
+// AzureCLISubscriptionID best-effort resolves the az CLI's active
+// subscription (the same one `az` commands run against), so onctl can
+// default azure.subscriptionId to it when the value in onctl.yaml is still
+// the placeholder or unset. Returns "" if az isn't installed/logged in or errors.
+func AzureCLISubscriptionID() string {
+	return runAzCLI("account", "show", "--query", "id", "-o", "tsv")
+}
+
+// AzureCLIDefaultResourceGroup best-effort resolves the az CLI's configured
+// default resource group (`az configure --defaults group=<name>`).
+// Most users won't have this set (opt-in), so empty is normal.
+func AzureCLIDefaultResourceGroup() string {
+	return runAzCLI("config", "get", "defaults.group", "--query", "value", "-o", "tsv")
 }

--- a/internal/providergcp/common.go
+++ b/internal/providergcp/common.go
@@ -3,6 +3,9 @@ package providergcp
 import (
 	"context"
 	"log"
+	"os/exec"
+	"strings"
+	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
 )
@@ -23,4 +26,26 @@ func GetGroupClient() *compute.InstanceGroupsClient {
 		log.Fatalln(err)
 	}
 	return client
+}
+
+// GCloudDefaultProject best-effort resolves the gcloud CLI's active project
+// (the same project `gcloud` commands run against), so onctl can default
+// gcp.project to it when the value in onctl.yaml is still the placeholder
+// or otherwise unset. Returns "" if gcloud isn't installed, isn't configured,
+// or errors out (with a short timeout).
+func GCloudDefaultProject() string {
+	if _, err := exec.LookPath("gcloud"); err != nil {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "gcloud", "config", "get-value", "project").Output()
+	if err != nil {
+		return ""
+	}
+	project := strings.TrimSpace(string(out))
+	if project == "" || project == "(unset)" {
+		return ""
+	}
+	return project
 }


### PR DESCRIPTION
## Summary

Finishes the single `onctl.yaml` migration by wiring the same generic + provider-specific CLI flags for **GCP** and **Azure** that were previously added for Hetzner and AWS.

### What changed
- `--type`, `--location`, `--username` now correctly drive `gcp.*` and `azure.*` settings (just like hetzner/aws).
- New flags:
  - `--project` for GCP (with gcloud fallback).
  - `--subscription-id` and `--resource-group` for Azure (with `az` CLI fallbacks).
- Added helpers:
  - `GCloudDefaultProject()` in providergcp.
  - `AzureCLISubscriptionID()` + `AzureCLIDefaultResourceGroup()` in providerazure.
- `resolveGCPProject()` / `resolveAzureIdentifiers()` run after loading `onctl.yaml` to replace the `<placeholder>` values when the cloud CLIs are configured.
- Updated tests (`flags_defaults_test.go`, `root_test.go`) and flag registration.
- All changes are minimal and isolated to 6 files.

### Why
Previously on `main`, `--type` (and friends) only affected Hetzner and AWS. GCP and Azure still read only from `onctl.yaml`. This makes the experience consistent for all providers and completes the "expose config as CLI flags" work started in the earlier zero-yaml PRs (adapted to the final single `onctl.yaml` model).

### Precedence (now uniform)
CLI flags > values in `.onctl/onctl.yaml` > resolve fallbacks from `gcloud`/`az` > hardcoded defaults in the template.

### Testing
- `go test ./cmd` passes (including new/updated flag bind + resolve tests).
- `onctl create --help` now shows the new flags.
- Bindings verified for `gcp.type`, `azure.vm.type`, etc.

Refs: feat/gcp-zero-yaml-flags, feat/azure-zero-yaml-flags + follow-up fix.

(Changes were prepared on clean cherry-picks from the integration work.)