### PR TITLE
fix: use imported host credentials for ssh -a/-u/-d on static provider

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -141,11 +141,11 @@ var sshCmd = &cobra.Command{
 
 		isDirectSSH := sshOpt.ConfigFile == "" && len(applyFileFound) == 0 && len(sshOpt.DownloadFiles) == 0 && len(sshOpt.UploadFiles) == 0
 		// Imported (static) hosts carry their own key/port from `onctl import`;
-		// skip requiring a global default key so static.SSHInto can fall back to them.
+		// skip reading the global default key — we'll load credentials from inventory below.
 		usesImportedKey := cloudProvider == "static" && sshOpt.Key == ""
 
 		var privateKey []byte
-		if !(isDirectSSH && usesImportedKey) {
+		if !usesImportedKey {
 			pk, err := os.ReadFile(privateKeyFile)
 			if err != nil {
 				log.Fatal(err)
@@ -162,6 +162,23 @@ var sshCmd = &cobra.Command{
 			SSHPort:    sshOpt.Port,
 			PrivateKey: string(privateKey),
 			Spinner:    s,
+		}
+		// For imported (static) hosts, the username/port/key live in the
+		// inventory, not in viper config or global SSH defaults.
+		if cloudProvider == "static" {
+			if sp, spErr := staticProvider(); spErr == nil {
+				if h, hErr := sp.GetHost(args[0]); hErr == nil {
+					remote.Username = h.Username
+					if !cmd.Flags().Changed("port") {
+						remote.SSHPort = h.SSHPort
+					}
+					if sshOpt.Key == "" && h.PrivateKey != "" {
+						if pk, err := os.ReadFile(h.PrivateKey); err == nil {
+							remote.PrivateKey = string(pk)
+						}
+					}
+				}
+			}
 		}
 
 		if sshOpt.DotEnvFile != "" {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -173,8 +173,11 @@ var sshCmd = &cobra.Command{
 						remote.SSHPort = h.SSHPort
 					}
 					if sshOpt.Key == "" && h.PrivateKey != "" {
-						if pk, err := os.ReadFile(h.PrivateKey); err == nil {
+						_, privateKeyPath := getSSHKeyFilePaths(h.PrivateKey)
+						if pk, err := os.ReadFile(privateKeyPath); err == nil {
 							remote.PrivateKey = string(pk)
+						} else {
+							log.Println("[DEBUG] failed to read imported host private key:", err)
 						}
 					}
 				}

--- a/pkg/cloud/static.go
+++ b/pkg/cloud/static.go
@@ -105,9 +105,9 @@ func (p ProviderStatic) GetByName(serverName string) (Vm, error) {
 	return Vm{}, fmt.Errorf("no imported host found with name: %s", serverName)
 }
 
-// getHost is like GetByName but returns the raw StaticHost (with
+// GetHost is like GetByName but returns the raw StaticHost (with
 // username/port/key) needed to actually connect.
-func (p ProviderStatic) getHost(serverName string) (StaticHost, error) {
+func (p ProviderStatic) GetHost(serverName string) (StaticHost, error) {
 	inv, err := p.LoadInventory()
 	if err != nil {
 		return StaticHost{}, err
@@ -121,7 +121,7 @@ func (p ProviderStatic) getHost(serverName string) (StaticHost, error) {
 }
 
 func (p ProviderStatic) SSHInto(serverName string, port int, privateKey string, command []string) {
-	host, err := p.getHost(serverName)
+	host, err := p.GetHost(serverName)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- `onctl -p static ssh <name> -a <script>` (and `-u`/`-d`) was failing with `ssh: unable to authenticate` because the `tools.Remote` struct was built from viper config and CLI defaults, not the imported host's inventory entry
- `remote.Username` was always empty (`static.vm.username` is never set in viper)
- `remote.PrivateKey` used the global default key (`~/.ssh/id_rsa`) instead of the key specified at `onctl import` time
- `remote.SSHPort` defaulted to 22 instead of the imported host's stored port
- The `usesImportedKey` guard only short-circuited for direct interactive SSH (`isDirectSSH && usesImportedKey`), so `-a`/`-u`/`-d` always hit the broken path

## Fix

- Export `ProviderStatic.getHost` → `GetHost` so `cmd/ssh.go` can access inventory credentials
- Change the key-read guard from `!(isDirectSSH && usesImportedKey)` → `!usesImportedKey` to skip reading the default key for all static-provider operations when no `-k` flag is given
- After building `tools.Remote`, populate `Username`, `SSHPort`, and `PrivateKey` from the imported host's inventory entry (respecting explicit `-k`/`-P` flag overrides)

## Test plan

- [ ] `onctl import ax41 --ip <ip> --user root --key ~/.ssh/id_ed25519`
- [ ] `onctl -p static ssh ax41 -a some-script.sh` — should now authenticate correctly
- [ ] `onctl -p static ssh ax41` (interactive) — should still work as before
- [ ] `onctl -p static ssh ax41 -k /other/key -a script.sh` — explicit `-k` flag should override inventory key