### PR TITLE
fix: reduce SSH dial timeout from 7s to 2s for faster Firecracker polling

### DIFF
--- a/internal/tools/remote-run.go
+++ b/internal/tools/remote-run.go
@@ -94,7 +94,7 @@ func (r *Remote) NewSSHConnection() error {
 	config := &ssh.ClientConfig{
 		User:            r.Username,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Second * 7,
+		Timeout:         time.Second * 2,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(key),
 		},

--- a/internal/tools/remote-run.go
+++ b/internal/tools/remote-run.go
@@ -23,13 +23,14 @@ const (
 )
 
 type Remote struct {
-	Username   string
-	IPAddress  string
-	SSHPort    int
-	PrivateKey string
-	Passphrase string
-	Spinner    *ui.Spinner
-	Client     *ssh.Client
+	Username    string
+	IPAddress   string
+	SSHPort     int
+	PrivateKey  string
+	Passphrase  string
+	Spinner     *ui.Spinner
+	Client      *ssh.Client
+	DialTimeout time.Duration // 0 means default (7s); set to a shorter value for fast-retry polling
 }
 
 type RemoteRunConfig struct {
@@ -91,10 +92,14 @@ func (r *Remote) NewSSHConnection() error {
 		}
 	}
 	// Authentication
+	dialTimeout := r.DialTimeout
+	if dialTimeout == 0 {
+		dialTimeout = 7 * time.Second
+	}
 	config := &ssh.ClientConfig{
 		User:            r.Username,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Second * 2,
+		Timeout:         dialTimeout,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(key),
 		},
@@ -120,6 +125,7 @@ func (r *Remote) WaitForSSH(timeout string) {
 
 	timer := time.After(duration)
 
+	r.DialTimeout = 2 * time.Second
 	for {
 		select {
 		case <-timer:


### PR DESCRIPTION
## Summary

- Reduces `ssh.ClientConfig.Timeout` in `NewSSHConnection` from 7 s to 2 s
- Each failed attempt in `WaitForSSH` (used for Firecracker `-p fc`) previously blocked for up to 7 s on a TCP timeout before sleeping 3 s — 10 s per cycle
- With 2 s the per-cycle cost drops to 5 s, doubling the number of attempts within the default 3-minute budget and cutting the worst-case wait in half
- Established connections (post-boot) are unaffected — they succeed near-instantly regardless of the dial timeout

## Test plan

- [ ] `onctl create -p fc` — confirm SSH readiness message appears faster when VM boots quickly
- [ ] `onctl create -p fc` with a slow-booting VM — confirm it still retries until SSH is up within the timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015QRifixW8prQHHzetHqTKv