### PR TITLE
fix(fc): reconcile stale running/paused status against actual process liveness

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -192,6 +192,12 @@ var createCmd = &cobra.Command{
 		}
 
 		for _, vm := range list.List {
+			// A "stopped" fc record means the microVM's firecracker process died
+			// out-of-band (e.g. host reboot) and cannot be restarted in place —
+			// Deploy() recreates it instead, so it isn't a live duplicate to abort on.
+			if vm.Provider == "fc" && vm.Status == "stopped" {
+				continue
+			}
 			if vm.Name == opt.Vm.Name {
 				s.Stop()
 				fmt.Println("\033[31m✘\033[0m VM " + opt.Vm.Name + " exists. Aborting...")

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -24,6 +24,12 @@ const defaultFCKernelArgs = "console=ttyS0 reboot=k panic=1 pci=off"
 const (
 	fcStatusRunning = "running"
 	fcStatusPaused  = "paused"
+	// fcStatusStopped marks a microVM whose firecracker process is no longer
+	// alive even though its persisted metadata was last written as "running"
+	// or "paused" (e.g. the host rebooted, or the process crashed).
+	// Firecracker VMMs have no restart-from-disk: recovering from this state
+	// requires destroying and redeploying the microVM.
+	fcStatusStopped = "stopped"
 )
 
 // FCConfig holds configuration for the local Firecracker microVM provider.
@@ -162,6 +168,35 @@ func saveFCMetadata(path string, vm fcVM) error {
 	return os.WriteFile(path, data, 0600)
 }
 
+// isAlive reports whether vm's firecracker process is actually running and
+// still bound to vm's socket, guarding against a persisted PID that is
+// either dead or was reused by an unrelated process after a VMM exit or
+// host reboot.
+func (p ProviderFC) isAlive(vm fcVM) bool {
+	return vm.PID > 0 && p.Process.IsRunning(vm.PID) && p.Process.Owns(vm.PID, vm.SocketPath)
+}
+
+// loadAndReconcile loads a microVM's on-disk metadata and, if its status
+// claims the process is running or paused but the firecracker process is no
+// longer alive, rewrites the persisted status to "stopped". Without this,
+// status read straight off disk (written once at Deploy/Pause/Resume time)
+// keeps reporting a microVM as live indefinitely after the process dies
+// out-of-band, e.g. a host reboot, which every running firecracker process
+// dies to.
+func (p ProviderFC) loadAndReconcile(path string) (fcVM, error) {
+	vm, err := loadFCMetadata(path)
+	if err != nil {
+		return fcVM{}, err
+	}
+	if vm.Status != fcStatusStopped && !p.isAlive(vm) {
+		vm.Status = fcStatusStopped
+		if err := saveFCMetadata(path, vm); err != nil {
+			log.Println("[DEBUG] failed to persist reconciled status for " + vm.Name + ": " + err.Error())
+		}
+	}
+	return vm, nil
+}
+
 func mapFCVM(vm fcVM) Vm {
 	return Vm{
 		Provider:  "fc",
@@ -283,7 +318,7 @@ func (p ProviderFC) listAll() ([]fcVM, error) {
 		if !e.IsDir() {
 			continue
 		}
-		vm, err := loadFCMetadata(filepath.Join(root, e.Name(), "metadata.json"))
+		vm, err := p.loadAndReconcile(filepath.Join(root, e.Name(), "metadata.json"))
 		if err != nil {
 			log.Println("[DEBUG] skipping " + e.Name() + ": " + err.Error())
 			continue
@@ -294,15 +329,29 @@ func (p ProviderFC) listAll() ([]fcVM, error) {
 }
 
 // Deploy creates and boots a new microVM. If a microVM with the same name
-// already exists, its current state is returned unchanged.
+// already exists and is alive, its current state is returned unchanged. If
+// its record is stale (the firecracker process is no longer running, e.g.
+// after a host reboot), the stale state is cleared and a fresh microVM is
+// deployed in its place.
 func (p ProviderFC) Deploy(server Vm) (Vm, error) {
 	if server.Name == "" {
 		return Vm{}, errors.New("vm name is required")
 	}
 
-	if existing, err := loadFCMetadata(p.metadataPath(server.Name)); err == nil {
-		log.Println("[DEBUG] microVM " + server.Name + " already exists")
-		return mapFCVM(existing), nil
+	if existing, err := p.loadAndReconcile(p.metadataPath(server.Name)); err == nil {
+		if existing.Status != fcStatusStopped {
+			log.Println("[DEBUG] microVM " + server.Name + " already exists")
+			return mapFCVM(existing), nil
+		}
+		log.Println("[DEBUG] microVM " + server.Name + " has a stale record (firecracker process is no longer running); recreating")
+		if existing.TapDevice != "" {
+			if err := p.Net.DeleteTap(existing.TapDevice); err != nil {
+				log.Println("[DEBUG] failed to delete stale tap device " + existing.TapDevice + ": " + err.Error())
+			}
+		}
+		if err := os.RemoveAll(p.vmDir(server.Name)); err != nil {
+			return Vm{}, fmt.Errorf("failed to remove stale microVM state: %w", err)
+		}
 	}
 
 	kernelImage := p.Config.KernelImage
@@ -496,7 +545,10 @@ func (p ProviderFC) Resume(server Vm) (Vm, error) {
 	return mapFCVM(vm), nil
 }
 
-// List returns all running (non-paused) managed microVMs.
+// List returns all non-paused managed microVMs (see ListPaused for paused
+// ones). A microVM whose firecracker process has died out-of-band (e.g. a
+// host reboot, which no firecracker VMM survives) is included with status
+// "stopped" rather than the stale "running" last written to disk.
 func (p ProviderFC) List() (VmList, error) {
 	all, err := p.listAll()
 	if err != nil {
@@ -529,7 +581,7 @@ func (p ProviderFC) ListPaused() (VmList, error) {
 
 // GetByName returns the named microVM, or a zero-value Vm if it doesn't exist.
 func (p ProviderFC) GetByName(serverName string) (Vm, error) {
-	vm, err := loadFCMetadata(p.metadataPath(serverName))
+	vm, err := p.loadAndReconcile(p.metadataPath(serverName))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return Vm{}, nil
@@ -559,6 +611,9 @@ func (p ProviderFC) SSHInto(serverName string, port int, privateKey string, comm
 	vm, err := p.GetByName(serverName)
 	if err != nil || vm.Name == "" {
 		log.Fatalln("no microVM found with name " + serverName)
+	}
+	if vm.Status == fcStatusStopped {
+		log.Fatalln("microVM " + serverName + " is not running (its firecracker process is gone, e.g. after a host reboot) — destroy and recreate it")
 	}
 	username := p.Config.Username
 	if username == "" {

--- a/pkg/cloud/fc_test.go
+++ b/pkg/cloud/fc_test.go
@@ -254,6 +254,67 @@ func TestProviderFC_Deploy_StartFailureCleansUp(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr))
 }
 
+// TestProviderFC_List_ReconcilesDeadProcess verifies that List() does not
+// keep reporting a microVM as running once its firecracker process is gone
+// out-of-band (e.g. the host rebooted, which every firecracker VMM dies to,
+// leaving the on-disk "running" status stale).
+func TestProviderFC_List_ReconcilesDeadProcess(t *testing.T) {
+	p, proc, _, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	running, err := p.List()
+	require.NoError(t, err)
+	require.Len(t, running.List, 1)
+	assert.Equal(t, fcStatusRunning, running.List[0].Status)
+
+	// Simulate a host reboot: the firecracker process is gone.
+	proc.running = map[int]bool{}
+
+	running, err = p.List()
+	require.NoError(t, err)
+	require.Len(t, running.List, 1, "a dead microVM is still surfaced, just with an honest status")
+	assert.Equal(t, fcStatusStopped, running.List[0].Status)
+
+	meta, err := loadFCMetadata(p.metadataPath("test-vm"))
+	require.NoError(t, err)
+	assert.Equal(t, fcStatusStopped, meta.Status, "status should self-heal on disk")
+}
+
+// TestProviderFC_Deploy_RecreatesStaleRecord verifies that Deploy() does not
+// silently no-op when a same-named microVM's record exists but its process
+// is dead — it should clean up the stale state and boot a fresh microVM.
+func TestProviderFC_Deploy_RecreatesStaleRecord(t *testing.T) {
+	p, proc, _, netMgr, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, proc.startCalls)
+
+	// Simulate a host reboot: the firecracker process is gone.
+	proc.running = map[int]bool{}
+
+	vm, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, proc.startCalls, "Deploy should recreate a stale microVM instead of no-op'ing")
+	assert.Equal(t, fcStatusRunning, vm.Status)
+	assert.Contains(t, netMgr.deleted, fcTapName("test-vm"), "the stale tap device should be cleaned up")
+}
+
+// TestProviderFC_GetByName_ReconcilesDeadProcess verifies GetByName reports
+// a dead microVM's status as stopped rather than the stale "running" value
+// last persisted before the process died.
+func TestProviderFC_GetByName_ReconcilesDeadProcess(t *testing.T) {
+	p, proc, _, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	proc.running = map[int]bool{}
+
+	vm, err := p.GetByName("test-vm")
+	require.NoError(t, err)
+	assert.Equal(t, fcStatusStopped, vm.Status)
+}
+
 func TestProviderFC_Destroy(t *testing.T) {
 	p, proc, _, netMgr, _ := newTestFCProvider(t)
 	_, err := p.Deploy(Vm{Name: "test-vm"})


### PR DESCRIPTION
## Summary

- \`onctl -p fc ls\` kept reporting Firecracker microVMs as \`running\` indefinitely after their firecracker process died out-of-band — the case that surfaced this: rebooting the host for a kernel upgrade. Every firecracker VMM process dies on host reboot, but nothing updates \`metadata.json\`'s persisted \`status\`, so \`List()\` just replayed the stale value forever.
- \`Deploy()\` had the same blind spot: it treated any existing \`metadata.json\` as proof the microVM was already up and returned it unchanged — so re-running \`onctl create\` for a dead microVM silently no-op'd instead of recreating it.
- \`Destroy()\` already guarded against this class of bug (checking \`Process.IsRunning\` + \`Process.Owns\` before signaling a persisted PID, to avoid killing an unrelated process that reused the PID after reboot) — this PR gives \`List\`/\`Deploy\`/\`GetByName\` the same treatment via a shared \`loadAndReconcile\` helper.

## Changes

- New \`fcStatusStopped\` status, and \`isAlive\`/\`loadAndReconcile\` helpers in \`pkg/cloud/fc.go\`.
- \`listAll()\` (used by \`List\`, \`ListPaused\`, \`usedIPs\`) now reconciles each record's status against actual process liveness, self-healing a stale \`running\`/\`paused\` status to \`stopped\` on disk.
- \`Deploy()\` redeploys over a \`stopped\` record (cleans up the stale tap device + state dir) instead of returning it unchanged.
- \`GetByName()\` reconciles too, so \`SSHInto\` sees an accurate status and now fails fast with a clear message instead of hanging against a dead socket.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./pkg/cloud/...\` — 0 issues
- [x] \`go test ./pkg/cloud/...\` — all passing, including 3 new tests:
  - \`TestProviderFC_List_ReconcilesDeadProcess\`
  - \`TestProviderFC_Deploy_RecreatesStaleRecord\`
  - \`TestProviderFC_GetByName_ReconcilesDeadProcess\`
- [x] Existing \`TestProviderFC_Deploy_Idempotent\` and \`TestProviderFC_PauseResume\` still pass unchanged, confirming reconciliation is a no-op when the process is genuinely alive.