### PR TITLE
fix(fc): use "dead" status, not "stopped", for a reboot-killed microVM

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -192,10 +192,10 @@ var createCmd = &cobra.Command{
 		}
 
 		for _, vm := range list.List {
-			// A "stopped" fc record means the microVM's firecracker process died
+			// A "dead" fc record means the microVM's firecracker process died
 			// out-of-band (e.g. host reboot) and cannot be restarted in place —
 			// Deploy() recreates it instead, so it isn't a live duplicate to abort on.
-			if vm.Provider == "fc" && vm.Status == "stopped" {
+			if vm.Provider == "fc" && vm.Status == "dead" {
 				continue
 			}
 			if vm.Name == opt.Vm.Name {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -30,6 +30,29 @@ func TestListCmd_FlagDefaults(t *testing.T) {
 	assert.Equal(t, "tab", output, "output flag should default to 'tab'")
 }
 
+// TestIsPausedStatus documents the cross-provider paused/resumable
+// convention (AWS "stopped", GCP "TERMINATED", Azure "...deallocated") and
+// guards against fc's "dead" status (a non-resumable, process-is-gone state
+// with no cross-provider equivalent) ever being folded back into it, which
+// would misreport a dead-after-host-reboot microVM as merely "paused" in
+// `onctl ls`.
+func TestIsPausedStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		want   bool
+	}{
+		{"stopped", true},
+		{"TERMINATED", true},
+		{"VM deallocated", true},
+		{"running", false},
+		{"paused", false},
+		{"dead", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isPausedStatus(tt.status), "status %q", tt.status)
+	}
+}
+
 // TestListCmd_PausedRowRenders verifies a paused server row (as produced by
 // ListPaused) renders through TabWriter without error — the separate PAUSED table.
 func TestListCmd_PausedRowRenders(t *testing.T) {

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -24,12 +24,15 @@ const defaultFCKernelArgs = "console=ttyS0 reboot=k panic=1 pci=off"
 const (
 	fcStatusRunning = "running"
 	fcStatusPaused  = "paused"
-	// fcStatusStopped marks a microVM whose firecracker process is no longer
+	// fcStatusDead marks a microVM whose firecracker process is no longer
 	// alive even though its persisted metadata was last written as "running"
 	// or "paused" (e.g. the host rebooted, or the process crashed).
 	// Firecracker VMMs have no restart-from-disk: recovering from this state
-	// requires destroying and redeploying the microVM.
-	fcStatusStopped = "stopped"
+	// requires destroying and redeploying the microVM. Deliberately not
+	// "stopped" — cmd.isPausedStatus treats that string as the cross-provider
+	// paused/resumable convention (AWS "stopped", GCP "TERMINATED", Azure
+	// "deallocated"), which "dead" is not: there is nothing to resume.
+	fcStatusDead = "dead"
 )
 
 // FCConfig holds configuration for the local Firecracker microVM provider.
@@ -178,7 +181,7 @@ func (p ProviderFC) isAlive(vm fcVM) bool {
 
 // loadAndReconcile loads a microVM's on-disk metadata and, if its status
 // claims the process is running or paused but the firecracker process is no
-// longer alive, rewrites the persisted status to "stopped". Without this,
+// longer alive, rewrites the persisted status to "dead". Without this,
 // status read straight off disk (written once at Deploy/Pause/Resume time)
 // keeps reporting a microVM as live indefinitely after the process dies
 // out-of-band, e.g. a host reboot, which every running firecracker process
@@ -188,8 +191,8 @@ func (p ProviderFC) loadAndReconcile(path string) (fcVM, error) {
 	if err != nil {
 		return fcVM{}, err
 	}
-	if vm.Status != fcStatusStopped && !p.isAlive(vm) {
-		vm.Status = fcStatusStopped
+	if vm.Status != fcStatusDead && !p.isAlive(vm) {
+		vm.Status = fcStatusDead
 		if err := saveFCMetadata(path, vm); err != nil {
 			log.Println("[DEBUG] failed to persist reconciled status for " + vm.Name + ": " + err.Error())
 		}
@@ -339,7 +342,7 @@ func (p ProviderFC) Deploy(server Vm) (Vm, error) {
 	}
 
 	if existing, err := p.loadAndReconcile(p.metadataPath(server.Name)); err == nil {
-		if existing.Status != fcStatusStopped {
+		if existing.Status != fcStatusDead {
 			log.Println("[DEBUG] microVM " + server.Name + " already exists")
 			return mapFCVM(existing), nil
 		}
@@ -548,7 +551,7 @@ func (p ProviderFC) Resume(server Vm) (Vm, error) {
 // List returns all non-paused managed microVMs (see ListPaused for paused
 // ones). A microVM whose firecracker process has died out-of-band (e.g. a
 // host reboot, which no firecracker VMM survives) is included with status
-// "stopped" rather than the stale "running" last written to disk.
+// "dead" rather than the stale "running" last written to disk.
 func (p ProviderFC) List() (VmList, error) {
 	all, err := p.listAll()
 	if err != nil {
@@ -612,7 +615,7 @@ func (p ProviderFC) SSHInto(serverName string, port int, privateKey string, comm
 	if err != nil || vm.Name == "" {
 		log.Fatalln("no microVM found with name " + serverName)
 	}
-	if vm.Status == fcStatusStopped {
+	if vm.Status == fcStatusDead {
 		log.Fatalln("microVM " + serverName + " is not running (its firecracker process is gone, e.g. after a host reboot) — destroy and recreate it")
 	}
 	username := p.Config.Username

--- a/pkg/cloud/fc_test.go
+++ b/pkg/cloud/fc_test.go
@@ -274,11 +274,11 @@ func TestProviderFC_List_ReconcilesDeadProcess(t *testing.T) {
 	running, err = p.List()
 	require.NoError(t, err)
 	require.Len(t, running.List, 1, "a dead microVM is still surfaced, just with an honest status")
-	assert.Equal(t, fcStatusStopped, running.List[0].Status)
+	assert.Equal(t, fcStatusDead, running.List[0].Status)
 
 	meta, err := loadFCMetadata(p.metadataPath("test-vm"))
 	require.NoError(t, err)
-	assert.Equal(t, fcStatusStopped, meta.Status, "status should self-heal on disk")
+	assert.Equal(t, fcStatusDead, meta.Status, "status should self-heal on disk")
 }
 
 // TestProviderFC_Deploy_RecreatesStaleRecord verifies that Deploy() does not
@@ -312,7 +312,7 @@ func TestProviderFC_GetByName_ReconcilesDeadProcess(t *testing.T) {
 
 	vm, err := p.GetByName("test-vm")
 	require.NoError(t, err)
-	assert.Equal(t, fcStatusStopped, vm.Status)
+	assert.Equal(t, fcStatusDead, vm.Status)
 }
 
 func TestProviderFC_Destroy(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #954. After that PR merged, a live report from `onctl -p fc ls` on `fc-hel1-01` (rebooted for a kernel upgrade) showed the orphaned microVM as **paused** — still wrong, just a different wrong status than before.

Root cause: #954's reconciliation persists a dead fc microVM's status as `"stopped"`. But `cmd/list.go`'s `isPausedStatus()` already treats the literal string `"stopped"` as the cross-provider paused/resumable convention:

```go
func isPausedStatus(status string) bool {
	return status == "stopped" ||
		status == "TERMINATED" ||
		strings.Contains(strings.ToLower(status), "deallocated")
}
```

That's correct for AWS/GCP/Azure — a "stopped" EC2 instance or "deallocated" Azure VM still exists and can be resumed. It's **not** correct for fc: a microVM whose firecracker process died (e.g. host reboot) has no restart-from-disk — recovering it means destroy + recreate. Reusing `"stopped"` collided with that check and folded the dead microVM into `onctl ls`'s **PAUSED** section, implying resumability it doesn't have — the exact kind of lie this whole fix exists to stop.

## Changes

- Renames `fcStatusStopped` → `fcStatusDead` (`"dead"`) throughout `pkg/cloud/fc.go` and the `fc`-specific duplicate-name check in `cmd/create.go`.
- Adds `TestIsPausedStatus` in `cmd/list_test.go` covering the AWS/GCP/Azure paused strings (`true`) alongside fc's `"dead"` (`false`), to lock in the distinction and catch any future status-string collision here.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./cmd/... ./pkg/cloud/...` — 0 issues
- [x] `go test ./pkg/cloud/... -run TestProviderFC` — all passing (renamed assertions)
- [x] `go test ./cmd/... -run "TestIsPausedStatus|TestListCmd"` — all passing, including the new regression test