### PR TITLE
fix(release): sign checksums with explicit GPG key in isolated keyring

### DIFF
--- a/.github/workflows/goreleaser-self-hosted-test.yml
+++ b/.github/workflows/goreleaser-self-hosted-test.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -m 700 -p "$GNUPGHOME"
-          echo "$GNUPGHOME" >> "$GITHUB_ENV"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
           fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')

--- a/.github/workflows/goreleaser-self-hosted-test.yml
+++ b/.github/workflows/goreleaser-self-hosted-test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
       - name: Import GPG Key
         run: |
           export GNUPGHOME="$RUNNER_TEMP/gnupg"

--- a/.github/workflows/goreleaser-self-hosted-test.yml
+++ b/.github/workflows/goreleaser-self-hosted-test.yml
@@ -28,8 +28,13 @@ jobs:
           cache: true
       - name: Import GPG Key
         run: |
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -m 700 -p "$GNUPGHOME"
+          echo "$GNUPGHOME" >> "$GITHUB_ENV"
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
+          fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')
+          echo "GPG_FINGERPRINT=$fingerprint" >> "$GITHUB_ENV"
       - name: install quill
         run: |
           curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
+          cache: false
       - name: Import GPG Key
         run: |
           export GNUPGHOME="$RUNNER_TEMP/gnupg"

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -m 700 -p "$GNUPGHOME"
-          echo "$GNUPGHOME" >> "$GITHUB_ENV"
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
           fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -27,8 +27,13 @@ jobs:
           cache: true
       - name: Import GPG Key
         run: |
+          export GNUPGHOME="$RUNNER_TEMP/gnupg"
+          mkdir -m 700 -p "$GNUPGHOME"
+          echo "$GNUPGHOME" >> "$GITHUB_ENV"
           echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --no-tty --batch
           gpg --list-secret-keys
+          fingerprint=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')
+          echo "GPG_FINGERPRINT=$fingerprint" >> "$GITHUB_ENV"
       - name: install quill
         run: |
           curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,14 @@ project_name: onctl
 
 signs:
   - artifacts: checksum
+    args:
+      - "--batch"
+      - "-u"
+      - "{{ .Env.GPG_FINGERPRINT }}"
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
 
 before:
   hooks:


### PR DESCRIPTION
## Summary
- Release signing was failing with `gpg: no default secret key: No public key` because the self-hosted release runner is persistent, not ephemeral — the shared `~/.gnupg` default keyring could end up without an unambiguous default signing key by the time GoReleaser ran.
- Import the GPG key into a job-scoped `$RUNNER_TEMP/gnupg` instead of the shared homedir, and have GoReleaser sign with the imported key's fingerprint explicitly (`-u {{ .Env.GPG_FINGERPRINT }}`) rather than relying on gpg's default-key guess.

## Test plan
- [x] `goreleaser check` validates the updated `.goreleaser.yml`
- [ ] Dry-run via `goreleaser-self-hosted-test.yml` (workflow_dispatch against an existing tag) to confirm signing succeeds end-to-end before it hits a real tag push