### PR TITLE
ci: switch GitHub-hosted workflows to onctl-4 self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   run:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     timeout-minutes: 5
     strategy:
       fail-fast: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,7 @@ jobs:
   dependabot-automerge:
     # Sadece Dependabot'un açtığı PR'larda çalışsın
     if: ${{ github.actor == 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/docu-deploy.yml
+++ b/.github/workflows/docu-deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Docusaurus
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     defaults:
         run:
             shell: bash
@@ -53,7 +53,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docu-test-deploy.yml
+++ b/.github/workflows/docu-test-deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-deploy:
     name: Test deployment
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     defaults:
         run:
             shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   run:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     timeout-minutes: 5
     strategy:
       fail-fast: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   security:
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     # if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run:
     name: Vuln
-    runs-on: ubuntu-latest
+    runs-on: onctl-4
     timeout-minutes: 5
     strategy:
       fail-fast: true


### PR DESCRIPTION
## Summary
- Switches all `ubuntu-latest` jobs to `runs-on: onctl-4`, targeting the runner label provisioned by the `onctl-runners` GitHub App installed on this repo.
- `goreleaser.yml`, `goreleaser-self-hosted-test.yml` (already self-hosted macOS), and `warm-go-cache.yml` (needs macOS to pre-build darwin stdlib) are left untouched.

## Note
OSSF Scorecard conventionally runs on GitHub-hosted runners since its results feed public supply-chain trust signals — moved it too per the "all except macOS" instruction, but flagging in case that's undesirable for `scorecard.yml` specifically.

## Test plan
- [ ] Confirm `onctl-4` runners pick up queued jobs (push/PR-triggered workflows) rather than hanging
- [ ] Confirm docker-based steps (if any) work on the onctl-4 runner image