### PR TITLE
fix(ssh): retry WaitForSSH every 500ms instead of 3s

### DIFF
--- a/internal/tools/remote-run.go
+++ b/internal/tools/remote-run.go
@@ -135,7 +135,7 @@ func (r *Remote) WaitForSSH(timeout string) {
 			if err := r.NewSSHConnection(); err == nil {
 				return
 			}
-			time.Sleep(3 * time.Second)
+			time.Sleep(500 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- `WaitForSSH` (used by the `fc` provider to detect when a freshly-booted microVM's sshd is up) slept a fixed 3s between failed dial attempts. Since sshd on Firecracker microVMs is typically reachable well under 3s after boot, this added ~2-2.5s of pure waiting on top of real boot time on every `onctl create`.
- Dropped the retry interval to 500ms so the loop converges close to actual readiness instead of a coarse 3s step.

## Test plan
- [x] `go build ./...` and `go test ./internal/tools/...` pass
- [x] Measured directly on `fc-host` with the `onctl-4` profile (4vcpu/16GB, baked `runner-base-docker.ext4`), back-to-back same-config runs:
  - unpatched: `onctl create` → 4.54s
  - patched: `onctl create` → 2.58s
- [x] Confirmed via `onctl list`/`onctl destroy` that test VMs were cleaned up and no production runners were disturbed

https://claude.ai/code/session_01XkRavfuW3YnmPieWTrgffn