### PR TITLE
fix(fmt): gofmt cmd/create.go and pkg/cloud/fc.go

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -42,8 +42,8 @@ var (
 	flagCloudInitTimeout string
 	// Firecracker-specific flags bound to fc.* viper keys (see init
 	// below). These replace the embedded fc.yaml from `onctl init`.
-	flagFCKernelImage string
-	flagFCRootfsImage string
+	flagFCKernelImage  string
+	flagFCRootfsImage  string
 	flagFCBinary       string
 	flagFCVCPU         int64
 	flagFCMemory       int64

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -170,24 +170,24 @@ type ProviderFC struct {
 
 // fcVM is the on-disk metadata persisted for each managed microVM.
 type fcVM struct {
-	Name        string    `json:"name"`
-	PID         int       `json:"pid"`
-	SocketPath  string    `json:"socketPath"`
-	TapDevice   string    `json:"tapDevice"`
-	IPAddress   string    `json:"ipAddress"`
-	MacAddress  string    `json:"macAddress"`
-	VCPUCount   int64     `json:"vcpuCount"`
-	MemSizeMib  int64     `json:"memSizeMib"`
-	Status      string    `json:"status"`
-	KernelImage string    `json:"kernelImage"`
+	Name        string `json:"name"`
+	PID         int    `json:"pid"`
+	SocketPath  string `json:"socketPath"`
+	TapDevice   string `json:"tapDevice"`
+	IPAddress   string `json:"ipAddress"`
+	MacAddress  string `json:"macAddress"`
+	VCPUCount   int64  `json:"vcpuCount"`
+	MemSizeMib  int64  `json:"memSizeMib"`
+	Status      string `json:"status"`
+	KernelImage string `json:"kernelImage"`
 	// CachePath is this VM's per-VM writable clone of CacheImage, if the
 	// cache feature was used at create time. Empty otherwise.
 	CachePath string `json:"cachePath,omitempty"`
 	// CacheImage is the golden image CachePath was cloned from, and the
 	// target for MergeBack at Destroy time.
-	CacheImage string `json:"cacheImage,omitempty"`
-	RootfsPath  string    `json:"rootfsPath"`
-	CreatedAt   time.Time `json:"createdAt"`
+	CacheImage string    `json:"cacheImage,omitempty"`
+	RootfsPath string    `json:"rootfsPath"`
+	CreatedAt  time.Time `json:"createdAt"`
 }
 
 func (p ProviderFC) vmDir(name string) string {


### PR DESCRIPTION
## Summary
- The "Go Format" CI check was failing on `main` (run 29522293868) because `cmd/create.go` and `pkg/cloud/fc.go`, added in 0bd8326, were not run through `gofmt -s`.
- Ran `gofmt -s -w` on both files; no behavior change, formatting only.

## Test plan
- [x] `gofmt -l .` returns no files
- [x] `go build ./...` succeeds