### PR TITLE
fix(fc): make pause/resume real disk snapshots, not just a vCPU freeze

### DIFF
--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -104,15 +104,28 @@ func GetConfig() cloud.FCConfig {
 // unixHTTPClient returns an HTTP client that talks to the Firecracker API
 // over its Unix domain socket.
 func unixHTTPClient(socketPath string) *http.Client {
+	return unixHTTPClientWithTimeout(socketPath, 5*time.Second)
+}
+
+// unixHTTPClientWithTimeout is unixHTTPClient with a caller-chosen timeout.
+// Snapshot create/load dump or map the entire guest memory to/from disk, so
+// they need far more than the 5s default other API calls use — how much
+// more scales with mem_size_mib, which onctl has no fixed bound on.
+func unixHTTPClientWithTimeout(socketPath string, timeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 			},
 		},
-		Timeout: 5 * time.Second,
+		Timeout: timeout,
 	}
 }
+
+// snapshotAPITimeout bounds Firecracker's /snapshot/create and
+// /snapshot/load calls, which are disk-I/O-bound on guest memory size
+// rather than the sub-second config calls the 5s default is sized for.
+const snapshotAPITimeout = 5 * time.Minute
 
 func fcRequest(client *http.Client, method, path string, body any) error {
 	data, err := json.Marshal(body)
@@ -220,6 +233,26 @@ func NewProcessManager(binPath string) cloud.FCProcess {
 }
 
 func (m ProcessManager) Start(socketPath string, cfg cloud.FCVMConfig, logFile string) (int, error) {
+	pid, err := m.spawn(socketPath, logFile)
+	if err != nil {
+		return 0, err
+	}
+	if err := configureAndBoot(socketPath, cfg); err != nil {
+		_ = m.Stop(pid)
+		return 0, err
+	}
+	return pid, nil
+}
+
+func (m ProcessManager) StartBare(socketPath, logFile string) (int, error) {
+	return m.spawn(socketPath, logFile)
+}
+
+// spawn launches the firecracker binary bound to socketPath and waits for
+// its API socket to come up, without configuring or booting it — the
+// shared first half of both Start (config comes from an FCVMConfig) and
+// StartBare (config comes from a snapshot loaded separately).
+func (m ProcessManager) spawn(socketPath, logFile string) (int, error) {
 	_ = os.Remove(socketPath)
 
 	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
@@ -242,11 +275,6 @@ func (m ProcessManager) Start(socketPath string, cfg cloud.FCVMConfig, logFile s
 	}
 
 	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
-		_ = m.Stop(pid)
-		return 0, err
-	}
-
-	if err := configureAndBoot(socketPath, cfg); err != nil {
 		_ = m.Stop(pid)
 		return 0, err
 	}
@@ -321,6 +349,32 @@ func NewAPIClient() cloud.FCAPI {
 func (APIClient) SetState(socketPath, state string) error {
 	client := unixHTTPClient(socketPath)
 	return fcRequest(client, http.MethodPatch, "/vm", map[string]string{"state": state})
+}
+
+func (APIClient) CreateSnapshot(socketPath, snapshotPath, memFilePath string) error {
+	client := unixHTTPClientWithTimeout(socketPath, snapshotAPITimeout)
+	return fcRequest(client, http.MethodPut, "/snapshot/create", map[string]string{
+		"snapshot_type": "Full",
+		"snapshot_path": snapshotPath,
+		"mem_file_path": memFilePath,
+	})
+}
+
+func (APIClient) LoadSnapshot(socketPath, snapshotPath, memFilePath string, resume bool, overrides []cloud.FCNetworkOverride) error {
+	client := unixHTTPClientWithTimeout(socketPath, snapshotAPITimeout)
+	body := map[string]any{
+		"snapshot_path": snapshotPath,
+		"mem_file_path": memFilePath,
+		"resume_vm":     resume,
+	}
+	if len(overrides) > 0 {
+		netOverrides := make([]map[string]string, len(overrides))
+		for i, o := range overrides {
+			netOverrides[i] = map[string]string{"iface_id": o.IfaceID, "host_dev_name": o.TapDevice}
+		}
+		body["network_overrides"] = netOverrides
+	}
+	return fcRequest(client, http.MethodPut, "/snapshot/load", body)
 }
 
 // LinuxNetworkManager is the real cloud.NetworkManager implementation,

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -110,6 +110,12 @@ type FCProcess interface {
 	// VMM bound to socketPath, guarding against a persisted PID having been
 	// reused by an unrelated process after a VMM exit or host reboot.
 	Owns(pid int, socketPath string) bool
+	// StartBare launches a firecracker process bound to socketPath without
+	// configuring or booting it — used for snapshot restore, where the full
+	// device configuration comes from the snapshot itself via
+	// FCAPI.LoadSnapshot rather than from an FCVMConfig. Returns the PID of
+	// the running process.
+	StartBare(socketPath, logFile string) (pid int, err error)
 }
 
 // FCAPI issues runtime control requests to a running firecracker
@@ -117,6 +123,26 @@ type FCProcess interface {
 type FCAPI interface {
 	// SetState transitions the microVM's state (e.g. "Paused" or "Resumed").
 	SetState(socketPath, state string) error
+	// CreateSnapshot writes a full snapshot of the VM's device state
+	// (snapshotPath) and guest memory (memFilePath). The VM must already be
+	// Paused via SetState. Together with the VM's rootfs image, these two
+	// files fully describe the microVM and can be copied to another host
+	// for LoadSnapshot there.
+	CreateSnapshot(socketPath, snapshotPath, memFilePath string) error
+	// LoadSnapshot restores a microVM from a snapshot previously written by
+	// CreateSnapshot into the freshly started (but unconfigured) process at
+	// socketPath. overrides re-maps snapshotted network interfaces to
+	// host-local TAP devices, which never survive a snapshot/restore since
+	// they're host-side only. If resume is true the VM's vCPUs are resumed
+	// immediately after load.
+	LoadSnapshot(socketPath, snapshotPath, memFilePath string, resume bool, overrides []FCNetworkOverride) error
+}
+
+// FCNetworkOverride re-maps a snapshotted network interface to a host-local
+// TAP device at LoadSnapshot time.
+type FCNetworkOverride struct {
+	IfaceID   string
+	TapDevice string
 }
 
 // NetworkManager creates/destroys the host-side networking for microVMs.
@@ -188,6 +214,14 @@ type fcVM struct {
 	CacheImage string    `json:"cacheImage,omitempty"`
 	RootfsPath string    `json:"rootfsPath"`
 	CreatedAt  time.Time `json:"createdAt"`
+	// SnapshotStatePath and SnapshotMemFilePath are the Firecracker
+	// snapshot files written by Pause, and consumed by Resume to restart
+	// the microVM. Empty unless Status is "paused". Both live under this
+	// VM's vmDir alongside its rootfs image, so copying that whole
+	// directory to another host's identically-configured StateDir (same
+	// VM name) is all "resume elsewhere" needs.
+	SnapshotStatePath   string `json:"snapshotStatePath,omitempty"`
+	SnapshotMemFilePath string `json:"snapshotMemFilePath,omitempty"`
 }
 
 func (p ProviderFC) vmDir(name string) string {
@@ -196,6 +230,14 @@ func (p ProviderFC) vmDir(name string) string {
 
 func (p ProviderFC) metadataPath(name string) string {
 	return filepath.Join(p.vmDir(name), "metadata.json")
+}
+
+func (p ProviderFC) snapshotStatePath(name string) string {
+	return filepath.Join(p.vmDir(name), "snapshot.snap")
+}
+
+func (p ProviderFC) snapshotMemFilePath(name string) string {
+	return filepath.Join(p.vmDir(name), "snapshot.mem")
 }
 
 func loadFCMetadata(path string) (fcVM, error) {
@@ -227,18 +269,20 @@ func (p ProviderFC) isAlive(vm fcVM) bool {
 }
 
 // loadAndReconcile loads a microVM's on-disk metadata and, if its status
-// claims the process is running or paused but the firecracker process is no
-// longer alive, rewrites the persisted status to "dead". Without this,
-// status read straight off disk (written once at Deploy/Pause/Resume time)
-// keeps reporting a microVM as live indefinitely after the process dies
-// out-of-band, e.g. a host reboot, which every running firecracker process
-// dies to.
+// claims the process is running but the firecracker process is no longer
+// alive, rewrites the persisted status to "dead". Without this, status read
+// straight off disk (written once at Deploy/Resume time) keeps reporting a
+// microVM as live indefinitely after the process dies out-of-band, e.g. a
+// host reboot, which every running firecracker process dies to. Paused VMs
+// are deliberately excluded: Pause stops the firecracker process on
+// purpose (that's the whole point — no compute cost while paused), so
+// !isAlive is expected there, not evidence of an unexpected death.
 func (p ProviderFC) loadAndReconcile(path string) (fcVM, error) {
 	vm, err := loadFCMetadata(path)
 	if err != nil {
 		return fcVM{}, err
 	}
-	if vm.Status != fcStatusDead && !p.isAlive(vm) {
+	if vm.Status != fcStatusDead && vm.Status != fcStatusPaused && !p.isAlive(vm) {
 		vm.Status = fcStatusDead
 		if err := saveFCMetadata(path, vm); err != nil {
 			log.Println("[DEBUG] failed to persist reconciled status for " + vm.Name + ": " + err.Error())
@@ -589,7 +633,7 @@ func (p ProviderFC) Destroy(server Vm) error {
 		// slightly staler cache state, still strictly better than
 		// discarding this job's compiled output entirely.
 		if p.isAlive(vm) {
-			p.flushCacheDiskGuest(vm)
+			p.flushGuestFilesystem(vm)
 		}
 		if err := p.Cache.MergeBack(vm.CachePath, vm.CacheImage); err != nil {
 			log.Println("[DEBUG] failed to merge cache disk back into " + vm.CacheImage + " for " + server.Name + ": " + err.Error())
@@ -610,20 +654,22 @@ func (p ProviderFC) Destroy(server Vm) error {
 	return os.RemoveAll(p.vmDir(server.Name))
 }
 
-// flushCacheDiskGuest asks vm's guest to flush all filesystem write
-// buffers (a global sync, not scoped to any particular mountpoint —
-// onctl has no visibility into where the cache drive was mounted, that's
-// an internal convention of whatever apply script attached it) before its
-// cache-disk changes are merged back into the golden image. Best-effort:
-// errors are only logged, never returned, so an unreachable guest can't
-// block Destroy.
-func (p ProviderFC) flushCacheDiskGuest(vm fcVM) {
+// flushGuestFilesystem asks vm's guest to flush all filesystem write
+// buffers (a global sync, not scoped to any particular mountpoint — onctl
+// has no visibility into where any given drive was mounted, that's an
+// internal convention of whatever apply script attached it). Used before
+// Destroy merges cache-disk changes back into the golden image, and before
+// a cold (non-hot) Pause snapshot, so the snapshot picks up a consistent
+// on-disk state rather than whatever was last flushed by the guest kernel's
+// own timers. Best-effort: errors are only logged, never returned, so an
+// unreachable guest can't block either caller.
+func (p ProviderFC) flushGuestFilesystem(vm fcVM) {
 	if p.Config.PrivateKey == "" || vm.IPAddress == "" {
 		return
 	}
 	key, err := os.ReadFile(p.Config.PrivateKey)
 	if err != nil {
-		log.Println("[DEBUG] failed to read SSH private key for cache-disk sync: " + err.Error())
+		log.Println("[DEBUG] failed to read SSH private key for guest filesystem sync: " + err.Error())
 		return
 	}
 	username := p.Config.Username
@@ -638,13 +684,20 @@ func (p ProviderFC) flushCacheDiskGuest(vm fcVM) {
 		DialTimeout: 5 * time.Second,
 	}
 	if _, err := r.RemoteRun(&tools.RemoteRunConfig{Command: "sync"}); err != nil {
-		log.Println("[DEBUG] cache-disk sync over SSH failed for " + vm.Name + " (proceeding with merge-back anyway): " + err.Error())
+		log.Println("[DEBUG] guest filesystem sync over SSH failed for " + vm.Name + " (proceeding anyway): " + err.Error())
 	}
 }
 
-// Pause freezes the microVM's vCPUs via the Firecracker API. The hot flag is
-// accepted for interface symmetry: a Firecracker pause is always a live,
-// in-memory vCPU freeze (no snapshot-to-disk), so there is no "cold" variant.
+// Pause freezes the microVM's vCPUs, writes a full Firecracker snapshot
+// (device state + guest memory) to disk under its vmDir, then stops the
+// firecracker process and tears down its TAP device — mirroring the other
+// providers' Pause (snapshot, then delete the compute so it stops costing
+// anything). The VM's rootfs image is left in place; together with the
+// snapshot files it fully describes the microVM, so copying the whole
+// vmDir to another host's identically-configured StateDir (same VM name)
+// and running Resume there restores it — the point of the exercise. hot
+// skips a best-effort guest filesystem sync first; the default (cold)
+// syncs so the snapshot picks up a consistent on-disk state.
 func (p ProviderFC) Pause(server Vm, hot bool) error {
 	vm, err := loadFCMetadata(p.metadataPath(server.Name))
 	if err != nil {
@@ -656,14 +709,46 @@ func (p ProviderFC) Pause(server Vm, hot bool) error {
 	if vm.Status == fcStatusPaused {
 		return nil
 	}
+	if !p.isAlive(vm) {
+		return fmt.Errorf("microVM %q is not running", server.Name)
+	}
+	if !hot {
+		p.flushGuestFilesystem(vm)
+	}
 	if err := p.API.SetState(vm.SocketPath, "Paused"); err != nil {
 		return fmt.Errorf("failed to pause microVM: %w", err)
 	}
+	statePath := p.snapshotStatePath(server.Name)
+	memPath := p.snapshotMemFilePath(server.Name)
+	if err := p.API.CreateSnapshot(vm.SocketPath, statePath, memPath); err != nil {
+		// Don't leave the microVM stuck frozen with nothing to show for it.
+		if resumeErr := p.API.SetState(vm.SocketPath, "Resumed"); resumeErr != nil {
+			log.Println("[DEBUG] failed to resume " + server.Name + " after a failed snapshot attempt: " + resumeErr.Error())
+		}
+		return fmt.Errorf("failed to snapshot microVM: %w", err)
+	}
+	if err := p.Process.Stop(vm.PID); err != nil {
+		return fmt.Errorf("microVM %q snapshotted but failed to stop its process (snapshot files at %s are still usable): %w", server.Name, p.vmDir(server.Name), err)
+	}
+	if vm.TapDevice != "" {
+		if err := p.Net.DeleteTap(vm.TapDevice); err != nil {
+			log.Println("[DEBUG] failed to delete tap device " + vm.TapDevice + " during pause: " + err.Error())
+		}
+	}
 	vm.Status = fcStatusPaused
+	vm.PID = 0
+	vm.SnapshotStatePath = statePath
+	vm.SnapshotMemFilePath = memPath
 	return saveFCMetadata(p.metadataPath(server.Name), vm)
 }
 
-// Resume unfreezes a paused microVM's vCPUs via the Firecracker API.
+// Resume restarts a paused microVM from the snapshot Pause wrote: it starts
+// a fresh (unconfigured) firecracker process, recreates the TAP device (TAP
+// devices are host-local and never survive a snapshot/restore), and loads
+// the snapshot into the new process with that TAP device network-overridden
+// in. Works unmodified against a vmDir copied in from another host, which
+// is the whole point — the snapshot + rootfs image is a fully portable
+// microVM.
 func (p ProviderFC) Resume(server Vm) (Vm, error) {
 	vm, err := loadFCMetadata(p.metadataPath(server.Name))
 	if err != nil {
@@ -675,9 +760,53 @@ func (p ProviderFC) Resume(server Vm) (Vm, error) {
 	if vm.Status != fcStatusPaused {
 		return mapFCVM(vm), nil
 	}
-	if err := p.API.SetState(vm.SocketPath, "Resumed"); err != nil {
-		return Vm{}, fmt.Errorf("failed to resume microVM: %w", err)
+	if vm.SnapshotStatePath == "" || vm.SnapshotMemFilePath == "" {
+		return Vm{}, fmt.Errorf("microVM %q has no snapshot to resume from", server.Name)
 	}
+	if _, err := os.Stat(vm.SnapshotStatePath); err != nil {
+		return Vm{}, fmt.Errorf("snapshot state file for %q: %w", server.Name, err)
+	}
+	if _, err := os.Stat(vm.SnapshotMemFilePath); err != nil {
+		return Vm{}, fmt.Errorf("snapshot memory file for %q: %w", server.Name, err)
+	}
+
+	bridge := p.Config.Bridge
+	if bridge == "" {
+		bridge = "fcbr0"
+	}
+	cidr := p.Config.CIDR
+	if cidr == "" {
+		cidr = "172.16.0.1/24"
+	}
+	if err := p.Net.EnsureBridge(bridge, cidr); err != nil {
+		return Vm{}, fmt.Errorf("failed to set up bridge %q: %w", bridge, err)
+	}
+
+	tapDevice := vm.TapDevice
+	if tapDevice == "" {
+		tapDevice = fcTapName(server.Name)
+	}
+	if err := p.Net.CreateTap(tapDevice, bridge); err != nil {
+		return Vm{}, fmt.Errorf("failed to create tap device: %w", err)
+	}
+
+	logFile := filepath.Join(p.vmDir(server.Name), "fc.log")
+	pid, err := p.Process.StartBare(vm.SocketPath, logFile)
+	if err != nil {
+		_ = p.Net.DeleteTap(tapDevice)
+		return Vm{}, fmt.Errorf("failed to start microVM process: %w", err)
+	}
+
+	if err := p.API.LoadSnapshot(vm.SocketPath, vm.SnapshotStatePath, vm.SnapshotMemFilePath, true, []FCNetworkOverride{
+		{IfaceID: "eth0", TapDevice: tapDevice},
+	}); err != nil {
+		_ = p.Process.Stop(pid)
+		_ = p.Net.DeleteTap(tapDevice)
+		return Vm{}, fmt.Errorf("failed to load microVM snapshot: %w", err)
+	}
+
+	vm.PID = pid
+	vm.TapDevice = tapDevice
 	vm.Status = fcStatusRunning
 	if err := saveFCMetadata(p.metadataPath(server.Name), vm); err != nil {
 		return Vm{}, err

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -739,7 +739,10 @@ func (p ProviderFC) Pause(server Vm, hot bool) error {
 	vm.PID = 0
 	vm.SnapshotStatePath = statePath
 	vm.SnapshotMemFilePath = memPath
-	return saveFCMetadata(p.metadataPath(server.Name), vm)
+	if err := saveFCMetadata(p.metadataPath(server.Name), vm); err != nil {
+		return fmt.Errorf("microVM %q snapshotted and stopped but failed to save metadata (snapshot files at %s are still usable): %w", server.Name, p.vmDir(server.Name), err)
+	}
+	return nil
 }
 
 // Resume restarts a paused microVM from the snapshot Pause wrote: it starts
@@ -809,7 +812,12 @@ func (p ProviderFC) Resume(server Vm) (Vm, error) {
 	vm.TapDevice = tapDevice
 	vm.Status = fcStatusRunning
 	if err := saveFCMetadata(p.metadataPath(server.Name), vm); err != nil {
-		return Vm{}, err
+		// Don't leave an unrecorded VMM running: a retried Resume would
+		// start a second process from the same snapshot and fight it for
+		// the API socket and TAP device.
+		_ = p.Process.Stop(pid)
+		_ = p.Net.DeleteTap(tapDevice)
+		return Vm{}, fmt.Errorf("microVM %q resumed but failed to save metadata: %w", server.Name, err)
 	}
 	return mapFCVM(vm), nil
 }

--- a/pkg/cloud/fc_test.go
+++ b/pkg/cloud/fc_test.go
@@ -18,18 +18,32 @@ import (
 
 // fakeFCProcess is a test double for FCProcess.
 type fakeFCProcess struct {
-	pid        int
-	startCalls int
-	startErr   error
-	stopCalls  []int
-	running    map[int]bool
-	notOwned   map[int]bool
+	pid            int
+	startCalls     int
+	startErr       error
+	startBareCalls int
+	startBareErr   error
+	stopCalls      []int
+	running        map[int]bool
+	notOwned       map[int]bool
 }
 
 func (f *fakeFCProcess) Start(_ string, _ FCVMConfig, _ string) (int, error) {
 	f.startCalls++
 	if f.startErr != nil {
 		return 0, f.startErr
+	}
+	if f.running == nil {
+		f.running = map[int]bool{}
+	}
+	f.running[f.pid] = true
+	return f.pid, nil
+}
+
+func (f *fakeFCProcess) StartBare(_ string, _ string) (int, error) {
+	f.startBareCalls++
+	if f.startBareErr != nil {
+		return 0, f.startBareErr
 	}
 	if f.running == nil {
 		f.running = map[int]bool{}
@@ -54,12 +68,32 @@ func (f *fakeFCProcess) Owns(pid int, _ string) bool {
 
 // fakeFCAPI is a test double for FCAPI.
 type fakeFCAPI struct {
-	states []string
+	states            []string
+	snapshotCalls     []string // "snapshotPath|memFilePath"
+	createSnapshotErr error
+	loadCalls         []string // "snapshotPath|memFilePath"
+	loadSnapshotErr   error
 }
 
 func (f *fakeFCAPI) SetState(_ string, state string) error {
 	f.states = append(f.states, state)
 	return nil
+}
+
+func (f *fakeFCAPI) CreateSnapshot(_ string, snapshotPath, memFilePath string) error {
+	f.snapshotCalls = append(f.snapshotCalls, snapshotPath+"|"+memFilePath)
+	if f.createSnapshotErr != nil {
+		return f.createSnapshotErr
+	}
+	if err := os.WriteFile(snapshotPath, []byte("state"), 0600); err != nil {
+		return err
+	}
+	return os.WriteFile(memFilePath, []byte("mem"), 0600)
+}
+
+func (f *fakeFCAPI) LoadSnapshot(_ string, snapshotPath, memFilePath string, _ bool, _ []FCNetworkOverride) error {
+	f.loadCalls = append(f.loadCalls, snapshotPath+"|"+memFilePath)
+	return f.loadSnapshotErr
 }
 
 // fakeNetworkManager is a test double for NetworkManager.
@@ -498,12 +532,18 @@ func TestProviderFC_Destroy_CacheMergeBackFailureDoesNotBlockDestroy(t *testing.
 }
 
 func TestProviderFC_PauseResume(t *testing.T) {
-	p, _, api, _, _ := newTestFCProvider(t)
+	p, proc, api, net, _ := newTestFCProvider(t)
 	_, err := p.Deploy(Vm{Name: "test-vm"})
 	require.NoError(t, err)
 
 	require.NoError(t, p.Pause(Vm{Name: "test-vm"}, true))
 	assert.Equal(t, []string{"Paused"}, api.states)
+	assert.Len(t, api.snapshotCalls, 1)
+	// Pause stops the process and tears down the tap device — no compute
+	// cost while paused, matching the other providers' delete-the-server
+	// pause semantics.
+	assert.Equal(t, []int{proc.pid}, proc.stopCalls)
+	assert.Contains(t, net.deleted, fcTapName("test-vm"))
 
 	paused, err := p.ListPaused()
 	require.NoError(t, err)
@@ -514,14 +554,58 @@ func TestProviderFC_PauseResume(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, running.List)
 
+	// A paused VM's process is legitimately gone — GetByName must not
+	// reconcile it to "dead".
+	byName, err := p.GetByName("test-vm")
+	require.NoError(t, err)
+	assert.Equal(t, "paused", byName.Status)
+
 	vm, err := p.Resume(Vm{Name: "test-vm"})
 	require.NoError(t, err)
 	assert.Equal(t, "running", vm.Status)
-	assert.Equal(t, []string{"Paused", "Resumed"}, api.states)
+	assert.Len(t, api.loadCalls, 1)
+	assert.Equal(t, 1, proc.startBareCalls)
 
 	running, err = p.List()
 	require.NoError(t, err)
 	require.Len(t, running.List, 1)
+}
+
+func TestProviderFC_Pause_NotAlive(t *testing.T) {
+	p, proc, _, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	proc.running[proc.pid] = false
+
+	err = p.Pause(Vm{Name: "test-vm"}, true)
+	assert.Error(t, err)
+}
+
+func TestProviderFC_Pause_SnapshotFailureResumesInstead(t *testing.T) {
+	p, _, api, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	api.createSnapshotErr = errors.New("disk full")
+
+	err = p.Pause(Vm{Name: "test-vm"}, true)
+	assert.Error(t, err)
+	assert.Equal(t, []string{"Paused", "Resumed"}, api.states)
+
+	vm, err := p.GetByName("test-vm")
+	require.NoError(t, err)
+	assert.Equal(t, "running", vm.Status)
+}
+
+func TestProviderFC_Resume_MissingSnapshotFiles(t *testing.T) {
+	p, _, _, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	require.NoError(t, p.Pause(Vm{Name: "test-vm"}, true))
+
+	require.NoError(t, os.Remove(p.snapshotStatePath("test-vm")))
+
+	_, err = p.Resume(Vm{Name: "test-vm"})
+	assert.Error(t, err)
 }
 
 func TestProviderFC_Pause_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- `onctl pause`'s help text already promised "snapshot the VM's disk, preserve its IP, then delete the VM" — matching every other provider's cost-saving pause — but for the `fc` (Firecracker) provider it was only ever a live, in-memory vCPU freeze with the process left running. No disk snapshot was written, no compute was actually freed, and there was nothing portable to move a microVM to another host.
- `Pause` now writes a full Firecracker snapshot (device state + guest memory, via `/snapshot/create`) into the VM's state directory, stops the firecracker process, and tears down its TAP device — genuinely no compute cost while paused, like every other provider.
- `Resume` starts a fresh firecracker process and reloads it from that snapshot via `/snapshot/load`, remapping the TAP device through Firecracker's `network_overrides` (TAP devices are host-local and never survive a snapshot/restore).
- Since a paused VM's state directory already holds its rootfs image alongside the new snapshot files, copying that directory to another host with an identically-configured `StateDir` and running `onctl resume` there is now enough to relocate a microVM — this was the actual motivating use case (portable snapshots of long-running fc microVMs).
- Fixes a latent bug this surfaced: `loadAndReconcile` would have wrongly flipped paused VMs to `"dead"` now that pause legitimately stops their process (previously the process stayed alive, just frozen).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/cloud/... ./internal/providerfc/...` — 0 issues
- [x] `go test ./pkg/cloud/... ./internal/providerfc/...` — pass, including new coverage for pause-when-not-alive, snapshot-create failure (rolls back to Resumed instead of leaving the VM stuck frozen), and resume with a missing snapshot file
- [x] `go test ./...` — pass except two pre-existing failures in `./cmd` (`TestReadConfig_NoConfigDirectory`, `TestCreateFlagsBindToViper`) confirmed present on `main` before this change, unrelated
- [ ] Manual pause/resume against a real firecracker binary (see `TESTING-fc.md`'s existing `sudo ONCTL_CLOUD=fc onctl pause mv2 && sudo ONCTL_CLOUD=fc onctl resume mv2`), including copying a paused VM's state dir to a second host and resuming it there

🤖 Generated with [Claude Code](https://claude.com/claude-code)