### PR TITLE
fix(ssh): run trailing -- command even when -u/-d/-a flags are set

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -34,6 +34,14 @@ func parseRemoteCmd(osArgs []string) []string {
 	return nil
 }
 
+// shouldSSHInto reports whether provider.SSHInto should run: either an
+// explicit trailing `-- command` was given (regardless of -u/-d/-a/-f), or
+// this is a bare `ssh VM_NAME` invocation that should open an interactive
+// session.
+func shouldSSHInto(isDirectSSH bool, remoteCmd []string) bool {
+	return len(remoteCmd) > 0 || isDirectSSH
+}
+
 func parseSSHConfigFile(configFile string) (*cmdSSHOptions, error) {
 	file, err := os.Open(configFile)
 	if err != nil {
@@ -217,7 +225,11 @@ var sshCmd = &cobra.Command{
 		if len(sshOpt.DownloadFiles) > 0 {
 			ProcessDownloadSlice(sshOpt.DownloadFiles, remote)
 		}
-		if isDirectSSH {
+		remoteCmd := parseRemoteCmd(os.Args)
+		// Run the trailing `-- command` whenever one is given, even alongside
+		// -u/-d/-a/-f; previously it only ran on a bare `ssh VM` invocation, so
+		// it was silently dropped whenever those flags were also present.
+		if shouldSSHInto(isDirectSSH, remoteCmd) {
 			sshKey := privateKeyFile
 			sshPort := sshOpt.Port
 			if cloudProvider == "static" {
@@ -229,7 +241,7 @@ var sshCmd = &cobra.Command{
 					sshPort = 0
 				}
 			}
-			provider.SSHInto(args[0], sshPort, sshKey, parseRemoteCmd(os.Args))
+			provider.SSHInto(args[0], sshPort, sshKey, remoteCmd)
 		}
 	},
 }

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -189,6 +189,45 @@ func TestParseRemoteCmd(t *testing.T) {
 	}
 }
 
+func TestShouldSSHInto(t *testing.T) {
+	tests := []struct {
+		name        string
+		isDirectSSH bool
+		remoteCmd   []string
+		expected    bool
+	}{
+		{
+			name:        "bare ssh with no other flags opens interactive session",
+			isDirectSSH: true,
+			remoteCmd:   nil,
+			expected:    true,
+		},
+		{
+			name:        "trailing command with no other flags runs it",
+			isDirectSSH: true,
+			remoteCmd:   []string{"uptime"},
+			expected:    true,
+		},
+		{
+			name:        "upload flag alone (isDirectSSH false) with no trailing command skips SSHInto",
+			isDirectSSH: false,
+			remoteCmd:   nil,
+			expected:    false,
+		},
+		{
+			name:        "upload flag combined with trailing command still runs the command",
+			isDirectSSH: false,
+			remoteCmd:   []string{"bash", "apply.sh"},
+			expected:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, shouldSSHInto(tt.isDirectSSH, tt.remoteCmd))
+		})
+	}
+}
+
 func TestCmdSSHOptions_ZeroValues(t *testing.T) {
 	// Test zero value cmdSSHOptions
 	var opts cmdSSHOptions


### PR DESCRIPTION
## Summary
- `provider.SSHInto` — the only code path that executes a trailing `-- command` on `onctl vm ssh` — was gated behind `isDirectSSH`, which required *no* `-u`/`-d`/`-a`/`-f` flags to be set.
- As a result, `onctl vm ssh host -u file.sh -- bash file.sh` uploaded the file and silently never ran the command: no error, no output, nothing.
- Extracted the decision into `shouldSSHInto(isDirectSSH, remoteCmd)`: run the trailing command whenever one is given (regardless of other flags), and still open an interactive session on a bare `ssh VM_NAME` call.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/...` — new `TestShouldSSHInto` covers bare ssh, trailing-command-alone, upload-only, and upload+trailing-command combinations
- [x] Confirmed two pre-existing failures (`TestReadConfig_NoConfigDirectory`, `TestCreateFlagsBindToViper`) are unrelated — they fail identically on `main` before this change