### PR TITLE
fix: fall back to another common SSH key type when the configured default is missing

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -244,12 +244,19 @@ func findSingleFile(filename string) (filePath string) {
 	return ""
 }
 
+// sshKeyTypeFallbackOrder lists the key basenames tried, in order, when the
+// configured default SSH key (ssh.publicKey/ssh.privateKey in onctl.yaml)
+// does not exist on disk. Newer, more secure key types are preferred first.
+var sshKeyTypeFallbackOrder = []string{"id_ed25519", "id_ecdsa", "id_rsa"}
+
 func getSSHKeyFilePaths(filename string) (publicKeyFile, privateKeyFile string) {
 
 	home, err := os.UserHomeDir()
 	if err != nil {
 		log.Println(err)
 	}
+
+	usingConfigDefault := filename == ""
 
 	if filename == "" {
 		publicKeyFile = viper.GetString("ssh.publicKey")
@@ -268,6 +275,30 @@ func getSSHKeyFilePaths(filename string) (publicKeyFile, privateKeyFile string) 
 	// change ~ char with home directory
 	publicKeyFile = strings.Replace(publicKeyFile, "~", home, 1)
 	privateKeyFile = strings.Replace(privateKeyFile, "~", home, 1)
+
+	// The configured default (ssh.publicKey/ssh.privateKey) may point to a
+	// key type the user never generated (e.g. onctl.yaml defaults to
+	// id_rsa, but the machine only has an id_ed25519 key). Rather than
+	// failing outright, fall back to another common key type that actually
+	// exists in the same directory. Explicit -k/--publicKey/--key values are
+	// never overridden this way.
+	if usingConfigDefault {
+		if _, statErr := os.Stat(publicKeyFile); statErr != nil {
+			keyDir := filepath.Dir(publicKeyFile)
+			for _, candidate := range sshKeyTypeFallbackOrder {
+				candidatePublic := filepath.Join(keyDir, candidate+".pub")
+				candidatePrivate := filepath.Join(keyDir, candidate)
+				if _, err := os.Stat(candidatePublic); err == nil {
+					if _, err := os.Stat(candidatePrivate); err == nil {
+						log.Println("[DEBUG] configured SSH key", publicKeyFile, "not found, falling back to", candidatePublic)
+						publicKeyFile = candidatePublic
+						privateKeyFile = candidatePrivate
+						break
+					}
+				}
+			}
+		}
+	}
 
 	log.Println("[DEBUG] publicKeyFile:", publicKeyFile)
 	log.Println("[DEBUG] privateKeyFile:", privateKeyFile)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -283,7 +283,9 @@ func getSSHKeyFilePaths(filename string) (publicKeyFile, privateKeyFile string) 
 	// exists in the same directory. Explicit -k/--publicKey/--key values are
 	// never overridden this way.
 	if usingConfigDefault {
-		if _, statErr := os.Stat(publicKeyFile); statErr != nil {
+		_, publicStatErr := os.Stat(publicKeyFile)
+		_, privateStatErr := os.Stat(privateKeyFile)
+		if publicStatErr != nil || privateStatErr != nil {
 			keyDir := filepath.Dir(publicKeyFile)
 			for _, candidate := range sshKeyTypeFallbackOrder {
 				candidatePublic := filepath.Join(keyDir, candidate+".pub")

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cdalar/onctl/internal/tools"
 	"github.com/gofrs/uuid/v5"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/duration"
 )
@@ -298,6 +299,36 @@ func TestGetSSHKeyFilePaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetSSHKeyFilePaths_FallsBackWhenConfiguredKeyMissing covers the
+// scenario where onctl.yaml's default ssh.publicKey/ssh.privateKey (id_rsa)
+// doesn't exist because the user only generated an id_ed25519 key pair.
+func TestGetSSHKeyFilePaths_FallsBackWhenConfiguredKeyMissing(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ssh-fallback-test-")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Only an ed25519 key pair exists on disk.
+	edPublic := filepath.Join(tmpDir, "id_ed25519.pub")
+	edPrivate := filepath.Join(tmpDir, "id_ed25519")
+	assert.NoError(t, os.WriteFile(edPublic, []byte("ssh-ed25519 AAAA..."), 0o600))
+	assert.NoError(t, os.WriteFile(edPrivate, []byte("fake-private-key"), 0o600))
+
+	// Config still points at the (nonexistent) id_rsa default.
+	origPublic := viper.GetString("ssh.publicKey")
+	origPrivate := viper.GetString("ssh.privateKey")
+	viper.Set("ssh.publicKey", filepath.Join(tmpDir, "id_rsa.pub"))
+	viper.Set("ssh.privateKey", filepath.Join(tmpDir, "id_rsa"))
+	defer func() {
+		viper.Set("ssh.publicKey", origPublic)
+		viper.Set("ssh.privateKey", origPrivate)
+	}()
+
+	publicKey, privateKey := getSSHKeyFilePaths("")
+
+	assert.Equal(t, edPublic, publicKey)
+	assert.Equal(t, edPrivate, privateKey)
 }
 
 func TestDirSize(t *testing.T) {

--- a/internal/files/init/onctl.yaml
+++ b/internal/files/init/onctl.yaml
@@ -12,6 +12,8 @@ vm:
   cloud-init:
     timeout: 3m                  # max wait for cloud-init to finish (e.g. 3m, 180s)
 ssh:
+  # If the key below doesn't exist, onctl falls back to another common
+  # type in the same directory (id_ed25519, id_ecdsa, id_rsa, in that order).
   publicKey: ~/.ssh/id_rsa.pub
   privateKey: ~/.ssh/id_rsa
 actions:


### PR DESCRIPTION
## Summary
- `onctl.yaml` defaults `ssh.publicKey`/`ssh.privateKey` to `~/.ssh/id_rsa(.pub)`, so `onctl up` fails outright (`open .../id_rsa.pub: no such file or directory`) on machines that only have an `id_ed25519` key pair.
- `getSSHKeyFilePaths` now falls back to another common key type (`id_ed25519`, `id_ecdsa`, `id_rsa`, in that priority order) in the same directory when the configured default doesn't exist on disk.
- Explicit `-k`/filename values are untouched — this fallback only applies to the config-driven default, so explicit user intent still fails loud if the file is missing.
- Documented the fallback in the shipped `internal/files/init/onctl.yaml` template.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/... -run TestGetSSHKeyFilePaths` — new fallback test + existing explicit-filename tests pass
- [x] `golangci-lint run ./cmd/...` — 0 issues
- [x] Confirmed two unrelated pre-existing test failures (`TestReadConfig_NoConfigDirectory`, `TestCreateFlagsBindToViper`) also fail identically on `main` (environment/config-dependent, unrelated to this change)