### PR TITLE
fix: default fc.stateDir to /opt/fc instead of $HOME

### DIFF
--- a/internal/files/init/onctl.yaml
+++ b/internal/files/init/onctl.yaml
@@ -80,4 +80,4 @@ fc:
     cidr: 172.16.0.1/24            # bridge address/subnet; address is the microVM gateway
   vm:
     username: root                 # ssh user configured in the rootfs image
-  # stateDir: ~/.onctl/firecracker  # default: ~/.onctl/firecracker
+  # stateDir: /opt/fc              # default: /opt/fc

--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -260,7 +260,9 @@ func (m ProcessManager) StartBare(socketPath, logFile string) (int, error) {
 func (m ProcessManager) spawn(socketPath, logFile string) (int, error) {
 	_ = os.Remove(socketPath)
 
-	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	// 0600: guest serial console output can contain sensitive boot/runtime
+	// data, and now lives under the world-traversable shared StateDir.
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open log file %q: %w", logFile, err)
 	}

--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -40,14 +40,19 @@ func expandHome(path string) string {
 	return path
 }
 
+// defaultFCStateDir is used when fc.stateDir isn't configured. Firecracker
+// microVM state is host-local, not per-user (Deploy needs CAP_NET_ADMIN to
+// set up the bridge/TAP devices anyway, so it's only ever usable as root or
+// a similarly privileged account) — a fixed system path avoids every user
+// account ending up with its own, inconsistent view of the same host's VMs.
+const defaultFCStateDir = "/opt/fc"
+
 // GetConfig reads fc.* settings from viper, applying defaults for
 // anything that isn't set.
 func GetConfig() cloud.FCConfig {
 	stateDir := viper.GetString("fc.stateDir")
 	if stateDir == "" {
-		if home, err := os.UserHomeDir(); err == nil {
-			stateDir = filepath.Join(home, ".onctl", "firecracker")
-		}
+		stateDir = defaultFCStateDir
 	} else {
 		stateDir = expandHome(stateDir)
 	}

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -96,11 +96,8 @@ func TestGetConfig_Defaults(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
 
-	home, err := os.UserHomeDir()
-	require.NoError(t, err)
-
 	cfg := GetConfig()
-	assert.Equal(t, filepath.Join(home, ".onctl", "firecracker"), cfg.StateDir)
+	assert.Equal(t, defaultFCStateDir, cfg.StateDir)
 	assert.Equal(t, int64(1), cfg.VCPUCount)
 	assert.Equal(t, int64(2048), cfg.MemSizeMib)
 	assert.Equal(t, "fcbr0", cfg.Bridge)

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -60,7 +60,7 @@ type FCConfig struct {
 	// BinPath is the path to the firecracker binary.
 	BinPath string
 	// StateDir is the directory onctl stores microVM state under
-	// (default ~/.onctl/firecracker).
+	// (default /opt/fc).
 	StateDir string
 	// CacheImage is the path to a persistent, host-owned cache disk image
 	// (ext4) attached as a second drive to every microVM, alongside the
@@ -257,7 +257,10 @@ func saveFCMetadata(path string, vm fcVM) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0600)
+	// 0644: metadata holds no secrets (paths, PID, IP/MAC, status) and must
+	// stay readable by other local accounts so `onctl ls` sees VMs deployed
+	// by root under the shared StateDir.
+	return os.WriteFile(path, data, 0644)
 }
 
 // isAlive reports whether vm's firecracker process is actually running and


### PR DESCRIPTION
## Summary
- Firecracker microVM state was tracked under each invoking user's `$HOME/.onctl/firecracker`, so `root` and a non-root user running `onctl ls` on the same host saw different, inconsistent VM lists.
- `Deploy` already requires `CAP_NET_ADMIN` (bridge/TAP setup) and is effectively root-only anyway, so per-user state directories provide no real isolation — they only hide the shared host resources (IP pool, TAP names, bridge) each user's VMs actually collide on.
- Default `fc.stateDir` to a single fixed host path, `/opt/fc`, instead of deriving it from `os.UserHomeDir()`.

## Migration note
Existing hosts with VM state under `~/.onctl/firecracker` (no `fc.stateDir` set) will need `/opt/fc` created (`sudo mkdir -p /opt/fc`) before deploying, or can pin `fc.stateDir: ~/.onctl/firecracker` in config to keep the old path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/providerfc/... ./pkg/cloud/...`
- [x] `go test ./internal/providerfc/... ./pkg/cloud/...`