### PR TITLE
fix(fc): don't treat EPERM as process-dead in IsRunning

### DIFF
--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -331,7 +331,17 @@ func (m ProcessManager) IsRunning(pid int) bool {
 	if err != nil {
 		return false
 	}
-	return process.Signal(syscall.Signal(0)) == nil
+	// Signaling with 0 delivers nothing but still probes existence. If the
+	// process is owned by a different user (e.g. onctl invoked as a
+	// non-root user querying a firecracker process started by root), the
+	// kernel returns EPERM rather than ESRCH -- that's proof the process
+	// exists, just that we can't signal it. Only treat "no such process"
+	// as evidence of death; any other error (permission denied included)
+	// must not be read as "not running", since Deploy() reclaims a "dead"
+	// microVM's on-disk state via os.RemoveAll, which would race a live
+	// firecracker process still holding that rootfs open.
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 // Owns reports whether pid is a firecracker process bound to socketPath, by

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -258,6 +258,19 @@ func TestProcessManager_IsRunning(t *testing.T) {
 	assert.True(t, pm.IsRunning(os.Getpid()))
 }
 
+// TestProcessManager_IsRunning_EPERM guards against regressing IsRunning to
+// treat "process exists but we can't signal it" (EPERM, e.g. it's owned by
+// another user) the same as "process doesn't exist" (ESRCH). PID 1 is
+// always alive and, when this test isn't running as root, always
+// unsignalable, giving a reliable EPERM without root privileges.
+func TestProcessManager_IsRunning_EPERM(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: PID 1 is signalable, can't force EPERM")
+	}
+	pm := ProcessManager{}
+	assert.True(t, pm.IsRunning(1), "EPERM on a live process must count as running, not dead")
+}
+
 func TestProcessManager_Stop_InvalidPID(t *testing.T) {
 	pm := ProcessManager{}
 	assert.NoError(t, pm.Stop(0))


### PR DESCRIPTION
## Summary
- `ProcessManager.IsRunning` used `kill(pid, 0) == nil` to decide whether a firecracker process is alive, but the kernel returns `EPERM` (not `ESRCH`) when the target process is owned by a different user — the old code treated that identically to "process doesn't exist."
- Reproduced live on a production fc host: querying a root-owned firecracker process as a non-root user reported it `dead` even though `ps`/the socket/the PID all showed it running fine.
- This isn't just a display bug: `List()`/`Deploy()` treat a `dead` verdict as license to `os.RemoveAll` the microVM's on-disk state (rootfs, log, metadata) and recreate it — racing a still-running firecracker process.
- Fix: only `ESRCH`-shaped absence (or a nil error) counts as "not running"; `EPERM` now counts as running, since it's proof the process exists.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/providerfc/... ./pkg/cloud/...`
- [x] Added `TestProcessManager_IsRunning_EPERM`, which forces a real EPERM via PID 1 (skips when running as root, since root can always signal PID 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kS5xpVLwn64qoq3nrt7cf