### PR TITLE
Add automated nightly build (rolling GitHub prerelease)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,16 @@ on:
 permissions:
   contents: write
 
+# Only one publish at a time: two overlapping pushes would otherwise both
+# delete+recreate the same `nightly` release independently, and whichever
+# run happens to finish last wins -- if that's the older push, the rolling
+# release goes stale until the next one. Cancelling any in-progress run as
+# soon as a newer push starts means the one that actually publishes is
+# always for the newest commit.
+concurrency:
+  group: nightly-build
+  cancel-in-progress: true
+
 jobs:
   nightly:
     runs-on: ubuntu-latest
@@ -42,6 +52,18 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Remove local nightly tag ref
+        # actions/checkout's fetch-depth: 0 also fetches every tag,
+        # including the rolling `nightly` one this workflow itself
+        # publishes. Left in place, GoReleaser's version discovery can
+        # pick `nightly` as "the current tag" (it's newer than the last
+        # real vX.Y.Z tag) and then fail outright trying to `incpatch` a
+        # non-semver tag -- reproduced live locally before adding this
+        # step. Deleting the local ref (the remote tag is untouched) means
+        # GoReleaser only ever sees real semver tags for version
+        # discovery, every run, regardless of whether `nightly` exists.
+        run: git tag -d nightly 2>/dev/null || true
 
       - name: Set up Go
         uses: actions/setup-go@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,70 @@
+name: nightly
+
+# Publishes an unsigned "nightly" build of onctl from the tip of main on
+# every push -- a Linux/Windows binary carrying whatever just landed (e.g.
+# #1074's per-VM guest hostname fix), for hosts like aimax to pick up
+# without waiting for a tagged, GPG-signed, Apple-notarized release
+# (goreleaser.yml's job, which this doesn't touch or replace).
+#
+# GoReleaser's own first-class "Nightlies" feature (--nightly flag +
+# nightly: config block) is Pro-only -- confirmed live: `goreleaser
+# release --help` on the installed 2.17.0 OSS CLI lists no --nightly flag,
+# and goreleaser.yml's own `distribution: goreleaser` (not
+# goreleaser-pro) + commented-out GORELEASER_KEY confirm this repo is on
+# the free tier. So this uses the OSS `--snapshot` flag instead (builds
+# unversioned artifacts, skips all publishing/validation) against a
+# dedicated .goreleaser.nightly.yml (Linux/Windows only -- no macOS build,
+# no quill signing, no homebrew tap publish, none of which apply here),
+# then this workflow publishes the result itself: deletes and recreates a
+# single rolling `nightly` prerelease/tag on every run, so there's always
+# exactly one, always-current release at a fixed URL
+# (github.com/cdalar/onctl/releases/tag/nightly) instead of a growing pile
+# of timestamped ones.
+#
+# Runs on a plain GH-hosted ubuntu-latest runner, not the self-hosted
+# macOS/ARM64 one goreleaser.yml uses -- that one exists specifically for
+# the macOS build's sign-and-notarize step, which this workflow never
+# builds at all.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Build snapshot artifacts
+        uses: goreleaser/goreleaser-action@v7.2.3
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean -f .goreleaser.nightly.yml --skip=publish
+
+      - name: Replace the rolling nightly release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release delete nightly --yes --cleanup-tag --repo cdalar/onctl 2>/dev/null || true
+          gh release create nightly dist/*.tar.gz dist/*.zip dist/checksums.txt \
+            --repo cdalar/onctl \
+            --target "${{ github.sha }}" \
+            --title "nightly ($(date -u +%Y-%m-%d))" \
+            --notes "Automated, unsigned build of main @ ${{ github.sha }}. Not a tagged release -- see the Releases page for stable, signed versions." \
+            --prerelease

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,0 +1,50 @@
+version: 2
+project_name: onctl
+
+# Used only by .github/workflows/nightly.yml -- a lighter, unsigned config
+# for continuous builds off the tip of main, separate from .goreleaser.yml
+# (real tagged releases: GPG-signed checksums, Apple-notarized macOS
+# binaries, homebrew tap publish). None of that applies to a nightly build,
+# so it's a dedicated config rather than reusing goreleaser.yml with skip
+# flags -- no macOS build (no quill/notarization credentials needed, and
+# the hosts consuming nightlies today, e.g. aimax, are Linux anyway), no
+# signs section, no homebrew_casks.
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - binary: onctl
+    id: onctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -w -s -X 'github.com/cdalar/onctl/cmd.Version=v{{.Version}}-{{.ShortCommit}}'
+
+archives:
+  - id: repl
+    name_template: "{{ .ProjectName }}-{{.Os}}-{{.Arch}}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: checksums.txt
+
+# --snapshot (the OSS equivalent used here, see this workflow's own header
+# comment for why) skips all validation, so .Version comes purely from this
+# template rather than the latest git tag -- distinguishes a nightly's
+# `onctl version` output from a real release at a glance.
+snapshot:
+  version_template: "{{ incpatch .Version }}-nightly"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yml` + `.goreleaser.nightly.yml`: builds and publishes an unsigned "nightly" onctl binary (Linux amd64/arm64, Windows amd64) from the tip of `main` on every push, as a single rolling `nightly` GitHub prerelease (always overwritten, always at `github.com/cdalar/onctl/releases/tag/nightly`) — so a host can pick up a just-merged fix (e.g. #1074's per-VM guest hostname) without waiting for a tagged, signed release.
- GoReleaser's own **Nightlies** feature is Pro-only — confirmed live: the installed OSS 2.17.0 CLI's `goreleaser release --help` has no `--nightly` flag, and this repo's `goreleaser.yml` already uses the free `distribution: goreleaser` (not `goreleaser-pro`, with `GORELEASER_KEY` commented out). Also checked whether a separate "beta" feature might be free instead — GoReleaser's own docs describe "beta builds or a rolling-release system" as just alternate phrasing for the same Pro-only Nightlies feature, not a distinct one.
- So this uses the free `--snapshot` flag (unversioned artifacts, skips all publishing/validation) against a **dedicated** `.goreleaser.nightly.yml` — Linux/Windows only, no macOS build, no GPG/quill signing, no homebrew tap publish, none of which apply to a nightly — then the workflow itself deletes+recreates the `nightly` release/tag via `gh release`, rather than reusing `goreleaser.yml`'s config with skip flags.
- Runs on plain GH-hosted `ubuntu-latest`, not the self-hosted macOS/ARM64 runner `goreleaser.yml` uses (that one exists only for the macOS notarization step, which this workflow never builds).

## Test plan
- [x] Validated `.goreleaser.nightly.yml` by actually running `goreleaser release --snapshot --clean -f .goreleaser.nightly.yml --skip=publish` locally — succeeded, produced real `linux_amd64`/`linux_arm64`/`windows_amd64` archives + checksums in ~34s
- [x] Extracted the linux/amd64 binary and confirmed it's a valid stripped ELF executable
- [x] YAML syntax validated for both new files
- [ ] First real run happens automatically once this merges (workflow triggers on push to `main`) — will check it publishes the `nightly` release correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F75TsjPk2tV2RD1rizu6eF