### PR TITLE
docs: add edge build install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ curl -sLS https://docs.onctl.io/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
+#### Edge build (latest `main`, Linux/Windows)
+
+To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
+
+```bash
+curl -sLS https://docs.onctl.io/get_edge.sh | bash
+sudo install onctl /usr/local/bin/
+```
+
 ### Windows 
 
 - download windows binary from [releases page](https://github.com/cdalar/onctl/releases)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,6 +45,15 @@ curl -sLS https://docs.onctl.io/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
+#### Edge build (latest `main`, Linux/Windows)
+
+To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
+
+```bash
+curl -sLS https://docs.onctl.io/get_edge.sh | bash
+sudo install onctl /usr/local/bin/
+```
+
 ### Windows 
 
 - download windows binary from [releases page](https://github.com/cdalar/onctl/releases)

--- a/docs/static/get_edge.sh
+++ b/docs/static/get_edge.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Installs the "edge" build of onctl: an unsigned snapshot built from the
+# tip of main on every push (see .github/workflows/edge.yml), published as
+# a single rolling prerelease at a fixed tag rather than a versioned one.
+# Linux/Windows only -- the edge workflow does not build macOS binaries.
+
+set -euo pipefail
+
+# Repository details
+REPO="cdalar/onctl"
+GITHUB="https://github.com"
+TAG="edge"
+
+# Determine system architecture
+architecture=$(uname -m)
+case $architecture in
+    x86_64)
+        arch="amd64"
+        ;;
+    arm64*|aarch64*)
+        arch="arm64"
+        ;;
+    *)
+        echo "Error: Unsupported architecture: $architecture"
+        exit 1
+        ;;
+esac
+
+# Determine operating system
+os=$(uname -s)
+case $os in
+    Linux)
+        os="linux"
+        extension=".tar.gz"
+        unzip_command="tar zxvf"
+        ;;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        os="windows"
+        extension=".zip"
+        unzip_command="unzip -o"
+        ;;
+    Darwin)
+        echo "Error: no edge build is published for macOS -- use 'brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev' instead."
+        exit 1
+        ;;
+    *)
+        echo "Error: Unsupported operating system: $os"
+        exit 1
+        ;;
+esac
+
+if [ "$os" = "windows" ] && [ "$arch" = "arm64" ]; then
+    echo "Error: no edge build is published for windows/arm64."
+    exit 1
+fi
+
+echo "Installing onctl edge build ($os/$arch) from the '$TAG' release"
+
+# Construct download URL -- must match .goreleaser.edge.yml's archive name_template
+download_url="$GITHUB/$REPO/releases/download/$TAG/onctl-${os}-${arch}${extension}"
+archive="onctl-${os}-${arch}-${TAG}${extension}"
+
+# Download the binary. --fail makes curl exit non-zero on an HTTP error
+# response (e.g. a stale/missing asset) instead of saving the error page as
+# if it were the archive; set -e above then stops the script right here
+# instead of it reaching the "complete" message with no usable binary.
+echo "Downloading onctl from $download_url"
+curl -fL "$download_url" -o "$archive"
+
+# Unzip the binary if on Windows or use tar command if on Linux
+if [ "$os" = "windows" ]; then
+    echo "Unzipping $archive"
+    $unzip_command "$archive" onctl.exe
+else
+    echo "Extracting $archive"
+    $unzip_command "$archive" onctl
+fi
+
+echo "Download and unzip complete. onctl binary is in the current directory."


### PR DESCRIPTION
## Summary
- Add `docs/static/get_edge.sh`, mirroring `get.sh` but pointed at the rolling `edge` release tag (Linux/Windows only, matching `.goreleaser.edge.yml`'s asset naming) so the unsigned main-branch build can be installed the same curl-pipe-bash way as the stable release.
- Document the new script in README.md and docs/docs/index.md under a new "Edge build" subsection.

## Test plan
- [x] `bash -n get_edge.sh` — syntax check
- [x] Ran the script live on macOS — correctly refused with a pointer to `onctl-dev` (no macOS edge build exists)
- [x] Ran a Linux-simulated copy — correctly downloaded and extracted the real `onctl-linux-amd64.tar.gz` asset from the current `edge` GitHub release
- [x] Confirmed asset names against the live `edge` release (`onctl-linux-amd64.tar.gz`, `onctl-linux-arm64.tar.gz`, `onctl-windows-amd64.zip`) match the script's URL construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoicQ3dFxTbvzgBRpUG6JM