### PR TITLE
Add Cloud Hypervisor (ch) provider for local microVMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Check 🌍 https://docs.onctl.io for detailed documentation
 - 🌍 Simple intuitive CLI to run VMs in seconds.  
 - ⛅️ Supports multi cloud providers (aws, azure, gcp, hetzner, more coming soon...)
 - 🔥 Run local microVMs with the `fc` (Firecracker) provider (Linux + KVM, no cloud account needed). No bare-metal Linux box? Create a nested-virtualization-enabled GCP VM (`gcp.vm.nestedVirtualization: true`) with `onctl create -n fc-host -a firecracker/firecracker-host-setup.sh`, then SSH in and run `ONCTL_CLOUD=fc onctl create -n my-microvm`.
+- 🐮 Run local microVMs with the `ch` ([Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)) provider — same idea as `fc` (Linux + KVM, no cloud account needed), no pause/resume support yet. Point `ch.kernelImage`/`ch.rootfsImage` at a kernel + rootfs image and run `ONCTL_CLOUD=ch onctl create -n my-microvm`.
 - 🚀 Sets your public key and Gives you SSH access with `onctl ssh <vm-name>`
 - ✨ Cloud-init support. Set your own cloud-init file `onctl up -n qwe --cloud-init <cloud.init.file>`
 - 🤖 Use ready to use templates to configure your vm. Check [onctl-templates](https://github.com/cdalar/onctl-templates) `onctl up -n qwe -a k3s/k3s-server.sh`

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -49,6 +49,11 @@ var (
 	flagFCMemory       int64
 	flagFCCacheImage   string
 	flagFCCacheSizeMib int64
+	// Cloud Hypervisor-specific flags bound to ch.* viper keys (see init
+	// below). --vcpu/--memory/--username are shared with fc (see above).
+	flagCHKernelImage string
+	flagCHRootfsImage string
+	flagCHBinary      string
 	// GCP-specific flag bound to gcp.project (see init below). This replaces
 	// the placeholder in onctl.yaml's gcp.project (the one GCP setting with
 	// no static default; it's account-specific).
@@ -149,6 +154,21 @@ func init() {
 	_ = viper.BindPFlag("fc.cacheImage", createCmd.Flags().Lookup("cache-image"))
 	_ = viper.BindPFlag("fc.cacheSizeMib", createCmd.Flags().Lookup("cache-size"))
 
+	// Cloud Hypervisor, each bound to the ch.* key read by
+	// providerch.GetConfig. --kernel-image/--rootfs-image/--binary can't be
+	// shared with fc's flags of the same purpose above: their defaults point
+	// at different image directories, and a shared flag can only carry one
+	// default value.
+	createCmd.Flags().StringVar(&flagCHKernelImage, "ch-kernel-image", "~/.onctl/cloud-hypervisor/images/vmlinux", "Cloud Hypervisor: path to the uncompressed kernel (vmlinux)")
+	createCmd.Flags().StringVar(&flagCHRootfsImage, "ch-rootfs-image", "~/.onctl/cloud-hypervisor/images/rootfs.ext4", "Cloud Hypervisor: path to the base rootfs (ext4)")
+	createCmd.Flags().StringVar(&flagCHBinary, "ch-binary", "cloud-hypervisor", "Cloud Hypervisor: path to the cloud-hypervisor binary")
+	_ = viper.BindPFlag("ch.kernelImage", createCmd.Flags().Lookup("ch-kernel-image"))
+	_ = viper.BindPFlag("ch.rootfsImage", createCmd.Flags().Lookup("ch-rootfs-image"))
+	_ = viper.BindPFlag("ch.binPath", createCmd.Flags().Lookup("ch-binary"))
+	_ = viper.BindPFlag("ch.vcpuCount", createCmd.Flags().Lookup("vcpu"))
+	_ = viper.BindPFlag("ch.memSizeMib", createCmd.Flags().Lookup("memory"))
+	_ = viper.BindPFlag("ch.vm.username", createCmd.Flags().Lookup("username"))
+
 	// Register create command at root level for convenience
 	rootCmd.AddCommand(createCmd)
 	createCmd.SetUsageTemplate(createCmd.UsageTemplate() + `
@@ -198,10 +218,10 @@ var createCmd = &cobra.Command{
 		}
 
 		for _, vm := range list.List {
-			// A "dead" fc record means the microVM's firecracker process died
+			// A "dead" fc/ch record means the microVM's VMM process died
 			// out-of-band (e.g. host reboot) and cannot be restarted in place —
 			// Deploy() recreates it instead, so it isn't a live duplicate to abort on.
-			if vm.Provider == "fc" && vm.Status == "dead" {
+			if (vm.Provider == "fc" || vm.Provider == "ch") && vm.Status == "dead" {
 				continue
 			}
 			if vm.Name == opt.Vm.Name {
@@ -305,7 +325,7 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		if cloudProvider != "fc" {
+		if cloudProvider != "fc" && cloudProvider != "ch" {
 			s.Suffix = " Waiting for VM to be ready..."
 			s.Restart()
 			remote.WaitForCloudInit(viper.GetString("vm.cloud-init.timeout"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cdalar/onctl/internal/provideraws"
 	"github.com/cdalar/onctl/internal/providerazure"
+	"github.com/cdalar/onctl/internal/providerch"
 	"github.com/cdalar/onctl/internal/providerfc"
 	"github.com/cdalar/onctl/internal/providergcp"
 	"github.com/cdalar/onctl/internal/providerhtz"
@@ -66,7 +67,7 @@ var (
 		},
 	}
 	cloudProvider     string
-	cloudProviderList = []string{"aws", "hetzner", "azure", "gcp", "fc", "static"}
+	cloudProviderList = []string{"aws", "hetzner", "azure", "gcp", "fc", "ch", "static"}
 	provider          cloud.CloudProviderInterface
 	providerFlag      string
 )
@@ -231,6 +232,14 @@ func initProvider(cloudProvider string) {
 			Net:     providerfc.NewNetworkManager(),
 			Rootfs:  providerfc.NewRootfsPreparer(),
 			Cache:   providerfc.NewCacheDiskPreparer(),
+		}
+	case "ch":
+		chConfig := providerch.GetConfig()
+		provider = &cloud.ProviderCH{
+			Config:  chConfig,
+			Process: providerch.NewProcessManager(chConfig.BinPath),
+			Net:     providerch.NewNetworkManager(),
+			Rootfs:  providerch.NewRootfsPreparer(),
 		}
 	case "static":
 		path, err := onctlSSHConfigPath()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -51,7 +51,7 @@ func TestCheckCloudProvider_WithEnvVar(t *testing.T) {
 
 func TestCloudProviderList(t *testing.T) {
 	// Test that cloud provider list contains expected providers
-	expectedProviders := []string{"aws", "hetzner", "azure", "gcp", "fc", "static"}
+	expectedProviders := []string{"aws", "hetzner", "azure", "gcp", "fc", "ch", "static"}
 	assert.Equal(t, expectedProviders, cloudProviderList)
 }
 

--- a/internal/files/init/onctl.yaml
+++ b/internal/files/init/onctl.yaml
@@ -83,3 +83,20 @@ fc:
   vm:
     username: root                 # ssh user configured in the rootfs image
   # stateDir: /opt/fc              # default: /opt/fc
+
+# ---- Cloud Hypervisor (ch) ----
+# Same idea as fc above (local VMM microVMs, no cloud account), but no
+# pause/resume/snapshot support yet.
+ch:
+  kernelImage: ~/.onctl/cloud-hypervisor/images/vmlinux  # uncompressed kernel (vmlinux)
+  rootfsImage: ~/.onctl/cloud-hypervisor/images/rootfs.ext4 # base rootfs, copied per-VM
+  # kernelArgs: "console=ttyS0 reboot=k panic=1 root=/dev/vda rw net.ifnames=0 biosdevname=0"
+  vcpuCount: 1
+  memSizeMib: 2048
+  binPath: cloud-hypervisor        # path to the cloud-hypervisor binary
+  network:
+    bridge: chbr0                  # host bridge microVM TAP devices attach to
+    cidr: 172.17.0.1/24            # bridge address/subnet; address is the microVM gateway
+  vm:
+    username: root                 # ssh user configured in the rootfs image
+  # stateDir: /opt/ch              # default: /opt/ch

--- a/internal/providerch/common.go
+++ b/internal/providerch/common.go
@@ -1,0 +1,560 @@
+// Package providerch provides the host-side implementations (process
+// management, networking, rootfs preparation) backing cloud.ProviderCH,
+// plus configuration loading from viper.
+package providerch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cdalar/onctl/pkg/cloud"
+	"github.com/spf13/viper"
+)
+
+// expandHome expands a leading "~" or "~/" in path to the user's home
+// directory. Config values come from a YAML file, so the shell never gets a
+// chance to expand "~" itself.
+func expandHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// defaultCHStateDir is used when ch.stateDir isn't configured. Cloud
+// Hypervisor microVM state is host-local, not per-user (Deploy needs
+// CAP_NET_ADMIN to set up the bridge/TAP devices anyway, so it's only ever
+// usable as root or a similarly privileged account) — a fixed system path
+// avoids every user account ending up with its own, inconsistent view of the
+// same host's VMs.
+const defaultCHStateDir = "/opt/ch"
+
+// GetConfig reads ch.* settings from viper, applying defaults for
+// anything that isn't set.
+func GetConfig() cloud.CHConfig {
+	stateDir := viper.GetString("ch.stateDir")
+	if stateDir == "" {
+		stateDir = defaultCHStateDir
+	} else {
+		stateDir = expandHome(stateDir)
+	}
+
+	vcpu := viper.GetInt64("ch.vcpuCount")
+	if vcpu == 0 {
+		vcpu = 1
+	}
+	mem := viper.GetInt64("ch.memSizeMib")
+	if mem == 0 {
+		mem = 2048
+	}
+
+	bridge := viper.GetString("ch.network.bridge")
+	cidr := viper.GetString("ch.network.cidr")
+
+	if bridge != "" && strings.Contains(bridge, "/") {
+		parts := strings.SplitN(bridge, "/", 2)
+		bridge = parts[0]
+		if parts[1] != "" {
+			cidr = parts[1]
+		}
+	}
+
+	if bridge == "" {
+		bridge = "chbr0"
+	}
+	if cidr == "" {
+		cidr = "172.17.0.1/24"
+	}
+
+	username := viper.GetString("ch.vm.username")
+	if username == "" {
+		username = "root"
+	}
+	binPath := viper.GetString("ch.binPath")
+	if binPath == "" {
+		binPath = "cloud-hypervisor"
+	}
+
+	return cloud.CHConfig{
+		KernelImage: expandHome(viper.GetString("ch.kernelImage")),
+		RootfsImage: expandHome(viper.GetString("ch.rootfsImage")),
+		KernelArgs:  viper.GetString("ch.kernelArgs"),
+		VCPUCount:   vcpu,
+		MemSizeMib:  mem,
+		Bridge:      bridge,
+		CIDR:        cidr,
+		Username:    username,
+		BinPath:     binPath,
+		StateDir:    stateDir,
+	}
+}
+
+// unixHTTPClient returns an HTTP client that talks to the Cloud Hypervisor
+// API over its Unix domain socket.
+func unixHTTPClient(socketPath string) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+}
+
+// chAPIBase is the fixed base path Cloud Hypervisor's REST API is served
+// under, regardless of the (irrelevant, since it's a Unix socket) host/port
+// in the URL.
+const chAPIBase = "http://localhost/api/v1"
+
+// chRequest issues an HTTP request against the Cloud Hypervisor API socket.
+// A nil body sends the request with no payload, for endpoints that take
+// none (e.g. vm.boot).
+func chRequest(client *http.Client, method, path string, body any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, chAPIBase+path, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("cloud-hypervisor API %s %s returned %s: %s", method, path, resp.Status, string(respBody))
+	}
+	return nil
+}
+
+// chVMConfigPayload is the body of a PUT /vm.create request. Only the fields
+// onctl needs are modeled; Cloud Hypervisor defaults everything else.
+type chVMConfigPayload struct {
+	CPUs    chCPUsConfig    `json:"cpus"`
+	Memory  chMemoryConfig  `json:"memory"`
+	Kernel  chKernelConfig  `json:"kernel"`
+	Cmdline chCmdlineConfig `json:"cmdline"`
+	Disks   []chDiskConfig  `json:"disks"`
+	Net     []chNetConfig   `json:"net"`
+	Serial  chConsoleConfig `json:"serial"`
+	Console chConsoleConfig `json:"console"`
+}
+
+type chCPUsConfig struct {
+	BootVCPUs int64 `json:"boot_vcpus"`
+	MaxVCPUs  int64 `json:"max_vcpus"`
+}
+
+type chMemoryConfig struct {
+	// Size is in bytes.
+	Size int64 `json:"size"`
+}
+
+type chKernelConfig struct {
+	Path string `json:"path"`
+}
+
+type chCmdlineConfig struct {
+	Args string `json:"args"`
+}
+
+type chDiskConfig struct {
+	Path string `json:"path"`
+}
+
+type chNetConfig struct {
+	Tap string `json:"tap"`
+	Mac string `json:"mac,omitempty"`
+}
+
+type chConsoleConfig struct {
+	Mode string `json:"mode"`
+}
+
+// configureAndBoot configures a freshly started cloud-hypervisor VMM over
+// its API socket and boots the microVM. Unlike Firecracker's per-resource
+// PUT calls, Cloud Hypervisor takes the whole VM config in one vm.create
+// call and boots it with a separate, bodyless vm.boot call.
+func configureAndBoot(socketPath string, cfg cloud.CHVMConfig) error {
+	client := unixHTTPClient(socketPath)
+
+	payload := chVMConfigPayload{
+		CPUs:    chCPUsConfig{BootVCPUs: cfg.VCPUCount, MaxVCPUs: cfg.VCPUCount},
+		Memory:  chMemoryConfig{Size: cfg.MemSizeMib * 1024 * 1024},
+		Kernel:  chKernelConfig{Path: cfg.KernelImage},
+		Cmdline: chCmdlineConfig{Args: cfg.KernelArgs},
+		Disks:   []chDiskConfig{{Path: cfg.RootfsPath}},
+		Net:     []chNetConfig{{Tap: cfg.TapDevice, Mac: cfg.MacAddress}},
+		// Tty: guest serial console output is written to the VMM process's
+		// own stdout, which spawn() redirects to logFile, mirroring how
+		// Firecracker's console output ends up in its log file.
+		Serial:  chConsoleConfig{Mode: "Tty"},
+		Console: chConsoleConfig{Mode: "Off"},
+	}
+	if err := chRequest(client, http.MethodPut, "/vm.create", payload); err != nil {
+		return fmt.Errorf("vm.create: %w", err)
+	}
+	if err := chRequest(client, http.MethodPut, "/vm.boot", nil); err != nil {
+		return fmt.Errorf("vm.boot: %w", err)
+	}
+	return nil
+}
+
+func waitForSocket(path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for cloud-hypervisor API socket %q", path)
+}
+
+// ProcessManager is the real cloud.CHProcess implementation: it spawns the
+// cloud-hypervisor binary, configures it over its API socket and manages the
+// resulting OS process.
+type ProcessManager struct {
+	BinPath string
+}
+
+// NewProcessManager returns a cloud.CHProcess backed by the cloud-hypervisor
+// binary at binPath ("cloud-hypervisor" if empty).
+func NewProcessManager(binPath string) cloud.CHProcess {
+	if binPath == "" {
+		binPath = "cloud-hypervisor"
+	}
+	return ProcessManager{BinPath: binPath}
+}
+
+func (m ProcessManager) Start(socketPath string, cfg cloud.CHVMConfig, logFile string) (int, error) {
+	pid, err := m.spawn(socketPath, logFile)
+	if err != nil {
+		return 0, err
+	}
+	if err := configureAndBoot(socketPath, cfg); err != nil {
+		_ = m.Stop(pid)
+		return 0, err
+	}
+	return pid, nil
+}
+
+// spawn launches the cloud-hypervisor binary bound to socketPath and waits
+// for its API socket to come up, without configuring or booting it.
+func (m ProcessManager) spawn(socketPath, logFile string) (int, error) {
+	_ = os.Remove(socketPath)
+
+	// 0600: guest serial console output can contain sensitive boot/runtime
+	// data, and now lives under the world-traversable shared StateDir.
+	logFd, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open log file %q: %w", logFile, err)
+	}
+	defer func() { _ = logFd.Close() }()
+
+	cmd := exec.Command(m.BinPath, "--api-socket", socketPath)
+	cmd.Stdout = logFd
+	cmd.Stderr = logFd
+	setSysProcAttr(cmd)
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to start %s: %w", m.BinPath, err)
+	}
+	pid := cmd.Process.Pid
+	// Detach: the microVM process must outlive this onctl invocation.
+	if err := cmd.Process.Release(); err != nil {
+		return 0, err
+	}
+
+	if err := waitForSocket(socketPath, 5*time.Second); err != nil {
+		_ = m.Stop(pid)
+		return 0, err
+	}
+
+	return pid, nil
+}
+
+func (m ProcessManager) Stop(pid int) error {
+	if pid <= 0 {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			return nil
+		}
+		return err
+	}
+	for i := 0; i < 50; i++ {
+		if !m.IsRunning(pid) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return process.Signal(syscall.SIGKILL)
+}
+
+func (m ProcessManager) IsRunning(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signaling with 0 delivers nothing but still probes existence. See
+	// providerfc.ProcessManager.IsRunning for why EPERM also counts as alive.
+	err = process.Signal(syscall.Signal(0))
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+// Owns reports whether pid is a cloud-hypervisor process bound to
+// socketPath, by checking its command line for a "--api-socket socketPath"
+// argument pair. This guards against a persisted PID having been reused by
+// an unrelated host process after a VMM exit or host reboot.
+func (m ProcessManager) Owns(pid int, socketPath string) bool {
+	if pid <= 0 || socketPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return false
+	}
+	args := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	for i, arg := range args {
+		if arg == "--api-socket" && i+1 < len(args) && args[i+1] == socketPath {
+			return true
+		}
+	}
+	return false
+}
+
+// LinuxNetworkManager is the real cloud.NetworkManager implementation,
+// shelling out to `ip` (iproute2). Creating bridges and TAP devices requires
+// CAP_NET_ADMIN (typically root).
+type LinuxNetworkManager struct{}
+
+// NewNetworkManager returns a cloud.NetworkManager backed by `ip`.
+func NewNetworkManager() cloud.NetworkManager {
+	return LinuxNetworkManager{}
+}
+
+func (LinuxNetworkManager) EnsureBridge(bridge, cidr string) error {
+	if linkExists(bridge) {
+		return nil
+	}
+	if err := runIP("link", "add", "name", bridge, "type", "bridge"); err != nil {
+		return err
+	}
+	if err := runIP("addr", "add", cidr, "dev", bridge); err != nil {
+		return err
+	}
+	return runIP("link", "set", bridge, "up")
+}
+
+func (LinuxNetworkManager) CreateTap(tapName, bridge string) error {
+	if linkExists(tapName) {
+		return nil
+	}
+	if err := runIP("tuntap", "add", "dev", tapName, "mode", "tap"); err != nil {
+		return err
+	}
+	if err := runIP("link", "set", tapName, "master", bridge); err != nil {
+		return err
+	}
+	return runIP("link", "set", tapName, "up")
+}
+
+func (LinuxNetworkManager) DeleteTap(tapName string) error {
+	if !linkExists(tapName) {
+		return nil
+	}
+	return runIP("link", "delete", tapName)
+}
+
+func linkExists(name string) bool {
+	return exec.Command("ip", "link", "show", name).Run() == nil
+}
+
+func runIP(args ...string) error {
+	out, err := exec.Command("ip", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ip %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// DebugfsRootfsPreparer is the real cloud.RootfsPreparer implementation: it
+// copies the base rootfs image and injects the SSH public key with debugfs,
+// avoiding the need to mount the image (and therefore root) on the host.
+type DebugfsRootfsPreparer struct{}
+
+// NewRootfsPreparer returns a cloud.RootfsPreparer backed by `debugfs`.
+func NewRootfsPreparer() cloud.RootfsPreparer {
+	return DebugfsRootfsPreparer{}
+}
+
+func (DebugfsRootfsPreparer) Prepare(baseImage, destPath, hostname, sshPublicKey, username string) error {
+	if baseImage == "" {
+		return errors.New("ch.rootfsImage is not configured")
+	}
+	if err := copyRootfs(baseImage, destPath); err != nil {
+		return fmt.Errorf("failed to copy base rootfs %q: %w", baseImage, err)
+	}
+	if hostname != "" {
+		if err := injectHostname(destPath, hostname); err != nil {
+			return err
+		}
+	}
+	if sshPublicKey == "" {
+		return nil
+	}
+	return injectSSHKey(destPath, sshPublicKey, username)
+}
+
+// copyRootfs creates dst as a copy of src, preferring a copy-on-write
+// reflink (near-instant and disk-space-free regardless of image size) and
+// falling back to a full byte-for-byte copy when the host filesystem
+// doesn't support reflinks (e.g. plain ext4, or non-Linux).
+func copyRootfs(src, dst string) error {
+	if err := reflinkCopy(src, dst); err == nil {
+		// `cp --reflink` preserves src's mode (typically a world/group-readable
+		// base image), but dst is a per-VM writable rootfs holding guest
+		// secrets under the shared, world-traversable StateDir — lock it down
+		// to match copyFile's fallback below, which os.OpenFile's it 0600.
+		return os.Chmod(dst, 0600)
+	}
+	return copyFile(src, dst)
+}
+
+func reflinkCopy(src, dst string) error {
+	out, err := exec.Command("cp", "--reflink=always", src, dst).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cp --reflink=always %s %s failed (requires a CoW filesystem like btrfs): %w: %s", src, dst, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// injectSSHKey writes publicKey to <home>/.ssh/authorized_keys inside the
+// ext-family image at rootfsPath using debugfs, without mounting the image.
+func injectSSHKey(rootfsPath, publicKey, username string) error {
+	homeDir := "/root"
+	if username != "root" {
+		homeDir = "/home/" + username
+	}
+	sshDir := homeDir + "/.ssh"
+
+	keyFile, err := os.CreateTemp("", "onctl-authorized-keys-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(keyFile.Name()) }()
+	if _, err := keyFile.WriteString(publicKey + "\n"); err != nil {
+		_ = keyFile.Close()
+		return err
+	}
+	if err := keyFile.Close(); err != nil {
+		return err
+	}
+
+	script := fmt.Sprintf(
+		"mkdir %s\nrm %s/authorized_keys\nwrite %s %s/authorized_keys\nsif %s/authorized_keys mode 0100600\nsif %s mode 040700\n",
+		sshDir, sshDir, keyFile.Name(), sshDir, sshDir, sshDir,
+	)
+	return runDebugfsScript(rootfsPath, script)
+}
+
+// injectHostname writes hostname to /etc/hostname inside the ext-family
+// image at rootfsPath using debugfs, without mounting the image.
+func injectHostname(rootfsPath, hostname string) error {
+	hostnameFile, err := os.CreateTemp("", "onctl-hostname-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(hostnameFile.Name()) }()
+	if _, err := hostnameFile.WriteString(hostname + "\n"); err != nil {
+		_ = hostnameFile.Close()
+		return err
+	}
+	if err := hostnameFile.Close(); err != nil {
+		return err
+	}
+
+	script := fmt.Sprintf(
+		"rm /etc/hostname\nwrite %s /etc/hostname\nsif /etc/hostname mode 0100644\n",
+		hostnameFile.Name(),
+	)
+	return runDebugfsScript(rootfsPath, script)
+}
+
+// runDebugfsScript writes script to a temp file and runs `debugfs -w` with
+// it against rootfsPath, shared by injectSSHKey and injectHostname.
+func runDebugfsScript(rootfsPath, script string) error {
+	scriptFile, err := os.CreateTemp("", "onctl-debugfs-*.script")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(scriptFile.Name()) }()
+	if _, err := scriptFile.WriteString(script); err != nil {
+		_ = scriptFile.Close()
+		return err
+	}
+	if err := scriptFile.Close(); err != nil {
+		return err
+	}
+
+	out, err := exec.Command("debugfs", "-w", "-f", scriptFile.Name(), rootfsPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("debugfs failed: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/providerch/common.go
+++ b/internal/providerch/common.go
@@ -162,8 +162,7 @@ func chRequest(client *http.Client, method, path string, body any) error {
 type chVMConfigPayload struct {
 	CPUs    chCPUsConfig    `json:"cpus"`
 	Memory  chMemoryConfig  `json:"memory"`
-	Kernel  chKernelConfig  `json:"kernel"`
-	Cmdline chCmdlineConfig `json:"cmdline"`
+	Payload chPayloadConfig `json:"payload"`
 	Disks   []chDiskConfig  `json:"disks"`
 	Net     []chNetConfig   `json:"net"`
 	Serial  chConsoleConfig `json:"serial"`
@@ -180,12 +179,12 @@ type chMemoryConfig struct {
 	Size int64 `json:"size"`
 }
 
-type chKernelConfig struct {
-	Path string `json:"path"`
-}
-
-type chCmdlineConfig struct {
-	Args string `json:"args"`
+// chPayloadConfig is Cloud Hypervisor's PayloadConfig: unlike Firecracker,
+// the kernel path and boot command line are plain string fields nested
+// under "payload", not top-level "kernel"/"cmdline" objects.
+type chPayloadConfig struct {
+	Kernel  string `json:"kernel"`
+	Cmdline string `json:"cmdline,omitempty"`
 }
 
 type chDiskConfig struct {
@@ -211,8 +210,7 @@ func configureAndBoot(socketPath string, cfg cloud.CHVMConfig) error {
 	payload := chVMConfigPayload{
 		CPUs:    chCPUsConfig{BootVCPUs: cfg.VCPUCount, MaxVCPUs: cfg.VCPUCount},
 		Memory:  chMemoryConfig{Size: cfg.MemSizeMib * 1024 * 1024},
-		Kernel:  chKernelConfig{Path: cfg.KernelImage},
-		Cmdline: chCmdlineConfig{Args: cfg.KernelArgs},
+		Payload: chPayloadConfig{Kernel: cfg.KernelImage, Cmdline: cfg.KernelArgs},
 		Disks:   []chDiskConfig{{Path: cfg.RootfsPath}},
 		Net:     []chNetConfig{{Tap: cfg.TapDevice, Mac: cfg.MacAddress}},
 		// Tty: guest serial console output is written to the VMM process's

--- a/internal/providerch/common_test.go
+++ b/internal/providerch/common_test.go
@@ -1,0 +1,135 @@
+package providerch
+
+// Tests for providerch package.
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cdalar/onctl/pkg/cloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startUnixServer serves mux over a fresh unix socket at sock, closing it on
+// test cleanup.
+func startUnixServer(t *testing.T, sock string, mux *http.ServeMux) {
+	t.Helper()
+	l, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(l) }()
+	t.Cleanup(func() { _ = server.Close() })
+}
+
+// shortTempDir is like t.TempDir() but short: the long, test-name-derived
+// paths t.TempDir() produces can exceed the ~104 byte AF_UNIX path limit on
+// macOS, causing net.Listen("unix", ...) to fail.
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "chsock")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestConfigureAndBoot_PayloadShape is a regression test for a review
+// finding: Cloud Hypervisor's vm.create expects the kernel path and boot
+// command line nested under a "payload" object ({"payload": {"kernel":
+// "...", "cmdline": "..."}}), not top-level "kernel"/"cmdline" objects like
+// an earlier draft sent. Decoding the exact bytes onctl puts on the wire
+// (rather than just asserting on Go struct fields) is what would have
+// caught this the first time.
+func TestConfigureAndBoot_PayloadShape(t *testing.T) {
+	sock := filepath.Join(shortTempDir(t), "api.sock")
+
+	var createBody map[string]any
+	var gotPaths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/vm.create", func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&createBody))
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v1/vm.boot", func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		assert.Equal(t, http.NoBody, r.Body, "vm.boot must be sent with no body")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	startUnixServer(t, sock, mux)
+
+	cfg := cloud.CHVMConfig{
+		KernelImage: "/images/vmlinux",
+		KernelArgs:  "console=ttyS0",
+		RootfsPath:  "/vms/test/rootfs.ext4",
+		VCPUCount:   2,
+		MemSizeMib:  1024,
+		TapDevice:   "ch0123456789abc",
+		MacAddress:  "02:C4:00:00:00:00",
+	}
+	require.NoError(t, configureAndBoot(sock, cfg))
+	assert.Equal(t, []string{"/api/v1/vm.create", "/api/v1/vm.boot"}, gotPaths)
+
+	require.Contains(t, createBody, "payload")
+	payload, ok := createBody["payload"].(map[string]any)
+	require.True(t, ok, "payload must be an object, got %T", createBody["payload"])
+	assert.Equal(t, cfg.KernelImage, payload["kernel"])
+	assert.Equal(t, cfg.KernelArgs, payload["cmdline"])
+	assert.NotContains(t, createBody, "kernel", "kernel must not be a top-level field")
+	assert.NotContains(t, createBody, "cmdline", "cmdline must not be a top-level field")
+
+	cpus, ok := createBody["cpus"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(cfg.VCPUCount), cpus["boot_vcpus"])
+	assert.Equal(t, float64(cfg.VCPUCount), cpus["max_vcpus"])
+
+	memory, ok := createBody["memory"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(cfg.MemSizeMib*1024*1024), memory["size"])
+
+	disks, ok := createBody["disks"].([]any)
+	require.True(t, ok)
+	require.Len(t, disks, 1)
+	assert.Equal(t, cfg.RootfsPath, disks[0].(map[string]any)["path"])
+
+	nets, ok := createBody["net"].([]any)
+	require.True(t, ok)
+	require.Len(t, nets, 1)
+	assert.Equal(t, cfg.TapDevice, nets[0].(map[string]any)["tap"])
+	assert.Equal(t, cfg.MacAddress, nets[0].(map[string]any)["mac"])
+}
+
+func TestConfigureAndBoot_CreateError(t *testing.T) {
+	sock := filepath.Join(shortTempDir(t), "api.sock")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/vm.create", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	startUnixServer(t, sock, mux)
+
+	err := configureAndBoot(sock, cloud.CHVMConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vm.create")
+}
+
+func TestConfigureAndBoot_BootError(t *testing.T) {
+	sock := filepath.Join(shortTempDir(t), "api.sock")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/vm.create", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v1/vm.boot", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	startUnixServer(t, sock, mux)
+
+	err := configureAndBoot(sock, cloud.CHVMConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vm.boot")
+}

--- a/internal/providerch/sysproc_unix.go
+++ b/internal/providerch/sysproc_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package providerch
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr starts the cloud-hypervisor process in a new session so it
+// outlives the parent onctl process. Setsid is Unix-only.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/providerch/sysproc_windows.go
+++ b/internal/providerch/sysproc_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package providerch
+
+import "os/exec"
+
+// setSysProcAttr is a no-op on Windows; Cloud Hypervisor does not run on
+// Windows.
+func setSysProcAttr(_ *exec.Cmd) {}

--- a/pkg/cloud/ch.go
+++ b/pkg/cloud/ch.go
@@ -1,0 +1,542 @@
+package cloud
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cdalar/onctl/internal/tools"
+	"golang.org/x/crypto/ssh"
+)
+
+// defaultCHKernelArgs are the boot args used when ch.kernelArgs is not set.
+// Unlike Firecracker (MMIO, no PCI), Cloud Hypervisor's virtio devices are
+// PCI, so the guest interface name depends on udev's predictable-naming
+// rules unless disabled — net.ifnames=0/biosdevname=0 keeps it "eth0", which
+// the ip= parameter (appended at deploy time) and the rest of onctl assume.
+// Cloud Hypervisor also has no Firecracker-style "is_root_device" flag: the
+// boot disk is just the first entry in the disks list, so root=/dev/vda is
+// required explicitly.
+const defaultCHKernelArgs = "console=ttyS0 reboot=k panic=1 root=/dev/vda rw net.ifnames=0 biosdevname=0"
+
+const (
+	chStatusRunning = "running"
+	// chStatusDead marks a microVM whose cloud-hypervisor process is no
+	// longer alive even though its persisted metadata was last written as
+	// "running" (e.g. the host rebooted, or the process crashed). There is
+	// no pause/resume support for this provider, so unlike fc there is no
+	// "paused" status to distinguish this from.
+	chStatusDead = "dead"
+)
+
+// CHConfig holds configuration for the local Cloud Hypervisor microVM
+// provider.
+type CHConfig struct {
+	// KernelImage is the path to the uncompressed Linux kernel image (vmlinux).
+	KernelImage string
+	// RootfsImage is the path to the base rootfs image used as a template for
+	// new microVMs (copied per-VM, never modified in place).
+	RootfsImage string
+	// KernelArgs are extra kernel boot arguments (network config is appended
+	// automatically).
+	KernelArgs string
+	// VCPUCount is the default vCPU count for new microVMs.
+	VCPUCount int64
+	// MemSizeMib is the default memory size (in MiB) for new microVMs.
+	MemSizeMib int64
+	// Bridge is the name of the host bridge device microVM TAP devices attach to.
+	Bridge string
+	// CIDR is the bridge's address and subnet (e.g. "172.17.0.1/24"). The
+	// bridge address is used as the gateway for microVMs.
+	CIDR string
+	// Username is the SSH user configured in the rootfs image.
+	Username string
+	// BinPath is the path to the cloud-hypervisor binary.
+	BinPath string
+	// StateDir is the directory onctl stores microVM state under
+	// (default /opt/ch).
+	StateDir string
+}
+
+// CHVMConfig describes a microVM to be configured and booted by a CHProcess.
+type CHVMConfig struct {
+	KernelImage string
+	KernelArgs  string
+	RootfsPath  string
+	VCPUCount   int64
+	MemSizeMib  int64
+	TapDevice   string
+	MacAddress  string
+}
+
+// CHProcess starts and stops cloud-hypervisor VMM processes.
+type CHProcess interface {
+	// Start launches a cloud-hypervisor process bound to socketPath,
+	// configures it per cfg over its API socket and boots it. It returns the
+	// PID of the running process.
+	Start(socketPath string, cfg CHVMConfig, logFile string) (pid int, err error)
+	// Stop terminates the cloud-hypervisor process with the given PID.
+	Stop(pid int) error
+	// IsRunning reports whether a process with the given PID is alive.
+	IsRunning(pid int) bool
+	// Owns reports whether the process with the given PID is the
+	// cloud-hypervisor VMM bound to socketPath, guarding against a persisted
+	// PID having been reused by an unrelated process after a VMM exit or
+	// host reboot.
+	Owns(pid int, socketPath string) bool
+}
+
+// ProviderCH manages local Cloud Hypervisor microVMs as onctl-managed VMs.
+// Unlike the other providers, there is no remote API: state is tracked on
+// disk under Config.StateDir, and Net/Process/Rootfs are local-host
+// operations. There is no pause/resume/snapshot support (see fc for that).
+type ProviderCH struct {
+	Config  CHConfig
+	Process CHProcess
+	Net     NetworkManager
+	Rootfs  RootfsPreparer
+}
+
+// chVM is the on-disk metadata persisted for each managed microVM.
+type chVM struct {
+	Name        string    `json:"name"`
+	PID         int       `json:"pid"`
+	SocketPath  string    `json:"socketPath"`
+	TapDevice   string    `json:"tapDevice"`
+	IPAddress   string    `json:"ipAddress"`
+	MacAddress  string    `json:"macAddress"`
+	VCPUCount   int64     `json:"vcpuCount"`
+	MemSizeMib  int64     `json:"memSizeMib"`
+	Status      string    `json:"status"`
+	KernelImage string    `json:"kernelImage"`
+	RootfsPath  string    `json:"rootfsPath"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+func (p ProviderCH) vmDir(name string) string {
+	return filepath.Join(p.Config.StateDir, "vms", name)
+}
+
+func (p ProviderCH) metadataPath(name string) string {
+	return filepath.Join(p.vmDir(name), "metadata.json")
+}
+
+func loadCHMetadata(path string) (chVM, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return chVM{}, err
+	}
+	var vm chVM
+	if err := json.Unmarshal(data, &vm); err != nil {
+		return chVM{}, err
+	}
+	return vm, nil
+}
+
+func saveCHMetadata(path string, vm chVM) error {
+	data, err := json.MarshalIndent(vm, "", "  ")
+	if err != nil {
+		return err
+	}
+	// 0644: metadata holds no secrets (paths, PID, IP/MAC, status) and must
+	// stay readable by other local accounts so `onctl ls` sees VMs deployed
+	// by root under the shared StateDir.
+	return os.WriteFile(path, data, 0644)
+}
+
+// isAlive reports whether vm's cloud-hypervisor process is actually running
+// and still bound to vm's socket, guarding against a persisted PID that is
+// either dead or was reused by an unrelated process after a VMM exit or
+// host reboot.
+func (p ProviderCH) isAlive(vm chVM) bool {
+	return vm.PID > 0 && p.Process.IsRunning(vm.PID) && p.Process.Owns(vm.PID, vm.SocketPath)
+}
+
+// loadAndReconcile loads a microVM's on-disk metadata and, if its status
+// claims the process is running but the cloud-hypervisor process is no
+// longer alive, rewrites the persisted status to "dead". See
+// ProviderFC.loadAndReconcile for the full rationale (identical here, minus
+// the paused-status exclusion, which doesn't apply to this provider).
+func (p ProviderCH) loadAndReconcile(path string) (chVM, error) {
+	vm, err := loadCHMetadata(path)
+	if err != nil {
+		return chVM{}, err
+	}
+	if vm.Status != chStatusDead && !p.isAlive(vm) {
+		vm.Status = chStatusDead
+		if err := saveCHMetadata(path, vm); err != nil {
+			log.Println("[DEBUG] failed to persist reconciled status for " + vm.Name + ": " + err.Error())
+		}
+	}
+	return vm, nil
+}
+
+func mapCHVM(vm chVM) Vm {
+	return Vm{
+		Provider:  "ch",
+		ID:        vm.Name,
+		Name:      vm.Name,
+		IP:        vm.IPAddress,
+		Type:      fmt.Sprintf("%dvcpu-%dmb", vm.VCPUCount, vm.MemSizeMib),
+		Image:     vm.RootfsPath,
+		Status:    vm.Status,
+		CreatedAt: vm.CreatedAt,
+	}
+}
+
+// parseCHType parses a "<vcpu>vcpu-<mem>mb" type string (e.g.
+// "2vcpu-1024mb"). If t is empty or doesn't match, the provided defaults are
+// returned.
+func parseCHType(t string, defaultVCPU, defaultMem int64) (vcpu, mem int64) {
+	if t == "" {
+		return defaultVCPU, defaultMem
+	}
+	var v, m int64
+	if _, err := fmt.Sscanf(strings.ToLower(t), "%dvcpu-%dmb", &v, &m); err == nil && v > 0 && m > 0 {
+		return v, m
+	}
+	return defaultVCPU, defaultMem
+}
+
+// chTapName derives a deterministic, <=15 char TAP device name from the VM
+// name (the Linux interface name length limit).
+func chTapName(vmName string) string {
+	sum := md5.Sum([]byte(vmName))
+	return "ch" + fmt.Sprintf("%x", sum)[:13]
+}
+
+// chMAC derives a deterministic, locally-administered MAC address from the
+// VM name.
+func chMAC(vmName string) string {
+	sum := md5.Sum([]byte(vmName))
+	return fmt.Sprintf("02:CH:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
+}
+
+// usedIPs returns the set of IP addresses already assigned to managed microVMs.
+func (p ProviderCH) usedIPs() (map[string]bool, error) {
+	all, err := p.listAll()
+	if err != nil {
+		return nil, err
+	}
+	used := make(map[string]bool, len(all))
+	for _, vm := range all {
+		if vm.IPAddress != "" {
+			used[vm.IPAddress] = true
+		}
+	}
+	return used, nil
+}
+
+// allocateAndReserveIP picks the next free IPv4 address in cidr and
+// immediately persists it as a metadata.json stub for name, all under an
+// exclusive lock. See ProviderFC.allocateAndReserveIP for the full
+// rationale (identical here).
+func (p ProviderCH) allocateAndReserveIP(name, cidr string) (string, error) {
+	lockPath := filepath.Join(p.Config.StateDir, "vms", ".ip.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return "", err
+	}
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return "", fmt.Errorf("failed to open IP allocation lock %q: %w", lockPath, err)
+	}
+	defer func() { _ = lockFile.Close() }()
+	if err := tools.Flock(lockFile); err != nil {
+		return "", fmt.Errorf("failed to lock %q: %w", lockPath, err)
+	}
+	defer func() { _ = tools.Funlock(lockFile) }()
+
+	used, err := p.usedIPs()
+	if err != nil {
+		return "", err
+	}
+	ip, err := allocateFCIP(cidr, used)
+	if err != nil {
+		return "", err
+	}
+	if err := saveCHMetadata(p.metadataPath(name), chVM{Name: name, IPAddress: ip, CreatedAt: time.Now()}); err != nil {
+		return "", fmt.Errorf("failed to reserve IP %s: %w", ip, err)
+	}
+	return ip, nil
+}
+
+// listAll returns the metadata for every managed microVM, regardless of status.
+func (p ProviderCH) listAll() ([]chVM, error) {
+	root := filepath.Join(p.Config.StateDir, "vms")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	vms := make([]chVM, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		vm, err := p.loadAndReconcile(filepath.Join(root, e.Name(), "metadata.json"))
+		if err != nil {
+			log.Println("[DEBUG] skipping " + e.Name() + ": " + err.Error())
+			continue
+		}
+		vms = append(vms, vm)
+	}
+	return vms, nil
+}
+
+// Deploy creates and boots a new microVM. If a microVM with the same name
+// already exists and is alive, its current state is returned unchanged. If
+// its record is stale (the cloud-hypervisor process is no longer running,
+// e.g. after a host reboot), the stale state is cleared and a fresh microVM
+// is deployed in its place.
+func (p ProviderCH) Deploy(server Vm) (Vm, error) {
+	if server.Name == "" {
+		return Vm{}, errors.New("vm name is required")
+	}
+
+	if existing, err := p.loadAndReconcile(p.metadataPath(server.Name)); err == nil {
+		if existing.Status != chStatusDead {
+			log.Println("[DEBUG] microVM " + server.Name + " already exists")
+			return mapCHVM(existing), nil
+		}
+		log.Println("[DEBUG] microVM " + server.Name + " has a stale record (cloud-hypervisor process is no longer running); recreating")
+		if existing.TapDevice != "" {
+			if err := p.Net.DeleteTap(existing.TapDevice); err != nil {
+				log.Println("[DEBUG] failed to delete stale tap device " + existing.TapDevice + ": " + err.Error())
+			}
+		}
+		if err := os.RemoveAll(p.vmDir(server.Name)); err != nil {
+			return Vm{}, fmt.Errorf("failed to remove stale microVM state: %w", err)
+		}
+	}
+
+	kernelImage := p.Config.KernelImage
+	rootfsImage := p.Config.RootfsImage
+	if server.Image != "" {
+		rootfsImage = server.Image
+	}
+	if kernelImage == "" || rootfsImage == "" {
+		return Vm{}, errors.New("ch.kernelImage and ch.rootfsImage must be configured (see onctl init)")
+	}
+
+	dir := p.vmDir(server.Name)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return Vm{}, fmt.Errorf("failed to create vm directory: %w", err)
+	}
+
+	vcpu, mem := parseCHType(server.Type, p.Config.VCPUCount, p.Config.MemSizeMib)
+
+	username := p.Config.Username
+	if username == "" {
+		username = "root"
+	}
+
+	var sshPublicKey string
+	if server.SSHKeyID != "" {
+		data, err := os.ReadFile(server.SSHKeyID)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to read SSH public key %q: %w", server.SSHKeyID, err)
+		}
+		sshPublicKey = strings.TrimSpace(string(data))
+	}
+
+	rootfsPath := filepath.Join(dir, "rootfs.ext4")
+	if err := p.Rootfs.Prepare(rootfsImage, rootfsPath, sanitizeGuestHostname(server.Name), sshPublicKey, username); err != nil {
+		_ = os.RemoveAll(dir)
+		return Vm{}, fmt.Errorf("failed to prepare rootfs: %w", err)
+	}
+
+	bridge := p.Config.Bridge
+	if bridge == "" {
+		bridge = "chbr0"
+	}
+	cidr := p.Config.CIDR
+	if cidr == "" {
+		cidr = "172.17.0.1/24"
+	}
+	if err := p.Net.EnsureBridge(bridge, cidr); err != nil {
+		_ = os.RemoveAll(dir)
+		return Vm{}, fmt.Errorf("failed to set up bridge %q: %w", bridge, err)
+	}
+
+	tapDevice := chTapName(server.Name)
+	if err := p.Net.CreateTap(tapDevice, bridge); err != nil {
+		_ = os.RemoveAll(dir)
+		return Vm{}, fmt.Errorf("failed to create tap device: %w", err)
+	}
+
+	ip, err := p.allocateAndReserveIP(server.Name, cidr)
+	if err != nil {
+		_ = p.Net.DeleteTap(tapDevice)
+		_ = os.RemoveAll(dir)
+		return Vm{}, err
+	}
+	gateway, mask, err := bridgeGatewayAndMask(cidr)
+	if err != nil {
+		_ = p.Net.DeleteTap(tapDevice)
+		_ = os.RemoveAll(dir)
+		return Vm{}, err
+	}
+
+	kernelArgs := strings.TrimSpace(p.Config.KernelArgs)
+	if kernelArgs == "" {
+		kernelArgs = defaultCHKernelArgs
+	}
+	kernelArgs = fmt.Sprintf("%s ip=%s::%s:%s::eth0:off", kernelArgs, ip, gateway, mask)
+
+	mac := chMAC(server.Name)
+	socketPath := filepath.Join(dir, "ch.sock")
+	logFile := filepath.Join(dir, "ch.log")
+
+	pid, err := p.Process.Start(socketPath, CHVMConfig{
+		KernelImage: kernelImage,
+		KernelArgs:  kernelArgs,
+		RootfsPath:  rootfsPath,
+		VCPUCount:   vcpu,
+		MemSizeMib:  mem,
+		TapDevice:   tapDevice,
+		MacAddress:  mac,
+	}, logFile)
+	if err != nil {
+		_ = p.Net.DeleteTap(tapDevice)
+		_ = os.RemoveAll(dir)
+		return Vm{}, fmt.Errorf("failed to start microVM: %w", err)
+	}
+
+	vm := chVM{
+		Name:        server.Name,
+		PID:         pid,
+		SocketPath:  socketPath,
+		TapDevice:   tapDevice,
+		IPAddress:   ip,
+		MacAddress:  mac,
+		VCPUCount:   vcpu,
+		MemSizeMib:  mem,
+		Status:      chStatusRunning,
+		KernelImage: kernelImage,
+		RootfsPath:  rootfsPath,
+		CreatedAt:   time.Now(),
+	}
+	if err := saveCHMetadata(p.metadataPath(server.Name), vm); err != nil {
+		return Vm{}, fmt.Errorf("microVM started but failed to persist metadata: %w", err)
+	}
+	return mapCHVM(vm), nil
+}
+
+// Destroy stops the microVM (if running), removes its TAP device and deletes
+// its on-disk state.
+func (p ProviderCH) Destroy(server Vm) error {
+	if server.Name == "" {
+		return errors.New("vm name is required")
+	}
+	vm, err := loadCHMetadata(p.metadataPath(server.Name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("no microVM found with name %q", server.Name)
+		}
+		return err
+	}
+	if vm.PID > 0 && p.Process.IsRunning(vm.PID) {
+		if !p.Process.Owns(vm.PID, vm.SocketPath) {
+			log.Println("[DEBUG] persisted PID " + fmt.Sprint(vm.PID) + " for " + server.Name + " is no longer the cloud-hypervisor process for this microVM; skipping stop")
+		} else if err := p.Process.Stop(vm.PID); err != nil {
+			return fmt.Errorf("failed to stop microVM: %w", err)
+		}
+	}
+	if vm.TapDevice != "" {
+		if err := p.Net.DeleteTap(vm.TapDevice); err != nil {
+			log.Println("[DEBUG] failed to delete tap device " + vm.TapDevice + ": " + err.Error())
+		}
+	}
+	return os.RemoveAll(p.vmDir(server.Name))
+}
+
+// Pause is not supported for the ch provider: there is no snapshot/restore
+// support (see fc for that). Use 'onctl destroy' instead.
+func (p ProviderCH) Pause(_ Vm, _ bool) error {
+	return errChUnsupported
+}
+
+// Resume is not supported for the ch provider (see Pause).
+func (p ProviderCH) Resume(_ Vm) (Vm, error) {
+	return Vm{}, errChUnsupported
+}
+
+var errChUnsupported = errors.New("not supported for the ch provider: pause/resume requires snapshot support, which this provider does not implement; use 'onctl destroy' and 'onctl create' instead")
+
+// List returns all managed microVMs. A microVM whose cloud-hypervisor
+// process has died out-of-band (e.g. a host reboot) is included with status
+// "dead" rather than the stale "running" last written to disk.
+func (p ProviderCH) List() (VmList, error) {
+	all, err := p.listAll()
+	if err != nil {
+		return VmList{}, err
+	}
+	var list VmList
+	for _, vm := range all {
+		list.List = append(list.List, mapCHVM(vm))
+	}
+	return list, nil
+}
+
+// ListPaused always returns an empty list: this provider has no pause support.
+func (p ProviderCH) ListPaused() (VmList, error) {
+	return VmList{}, nil
+}
+
+// GetByName returns the named microVM, or a zero-value Vm if it doesn't exist.
+func (p ProviderCH) GetByName(serverName string) (Vm, error) {
+	vm, err := p.loadAndReconcile(p.metadataPath(serverName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Vm{}, nil
+		}
+		return Vm{}, err
+	}
+	return mapCHVM(vm), nil
+}
+
+// CreateSSHKey validates the given public key file and returns its absolute
+// path. Unlike the remote providers there is no key registry to upload to:
+// Deploy reads the key directly from this path and injects it into the
+// microVM's rootfs.
+func (p ProviderCH) CreateSSHKey(publicKeyFile string) (keyID string, err error) {
+	data, err := os.ReadFile(publicKeyFile)
+	if err != nil {
+		return "", err
+	}
+	if _, _, _, _, err := ssh.ParseAuthorizedKey(data); err != nil {
+		return "", fmt.Errorf("invalid SSH public key %q: %w", publicKeyFile, err)
+	}
+	return filepath.Abs(publicKeyFile)
+}
+
+// SSHInto connects to the microVM over its TAP device IP address.
+func (p ProviderCH) SSHInto(serverName string, port int, privateKey string, command []string) {
+	vm, err := p.GetByName(serverName)
+	if err != nil || vm.Name == "" {
+		log.Fatalln("no microVM found with name " + serverName)
+	}
+	if vm.Status == chStatusDead {
+		log.Fatalln("microVM " + serverName + " is not running (its cloud-hypervisor process is gone, e.g. after a host reboot) — destroy and recreate it")
+	}
+	username := p.Config.Username
+	if username == "" {
+		username = "root"
+	}
+	tools.SSHIntoVM(tools.SSHIntoVMRequest{
+		IPAddress:      vm.IP,
+		User:           username,
+		Port:           port,
+		PrivateKeyFile: privateKey,
+		Command:        command,
+	})
+}

--- a/pkg/cloud/ch.go
+++ b/pkg/cloud/ch.go
@@ -212,10 +212,12 @@ func chTapName(vmName string) string {
 }
 
 // chMAC derives a deterministic, locally-administered MAC address from the
-// VM name.
+// VM name. Unlike fcMAC, the second octet can't spell out the provider name
+// in hex ("CH" isn't a valid hex byte — H isn't a hex digit), so it uses a
+// fixed placeholder octet instead.
 func chMAC(vmName string) string {
 	sum := md5.Sum([]byte(vmName))
-	return fmt.Sprintf("02:CH:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
+	return fmt.Sprintf("02:C4:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
 }
 
 // usedIPs returns the set of IP addresses already assigned to managed microVMs.

--- a/pkg/cloud/ch_test.go
+++ b/pkg/cloud/ch_test.go
@@ -1,0 +1,299 @@
+package cloud
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCHProcess is a test double for CHProcess.
+type fakeCHProcess struct {
+	pid        int
+	startCalls int
+	startErr   error
+	stopCalls  []int
+	running    map[int]bool
+	notOwned   map[int]bool
+}
+
+func (f *fakeCHProcess) Start(_ string, _ CHVMConfig, _ string) (int, error) {
+	f.startCalls++
+	if f.startErr != nil {
+		return 0, f.startErr
+	}
+	if f.running == nil {
+		f.running = map[int]bool{}
+	}
+	f.running[f.pid] = true
+	return f.pid, nil
+}
+
+func (f *fakeCHProcess) Stop(pid int) error {
+	f.stopCalls = append(f.stopCalls, pid)
+	delete(f.running, pid)
+	return nil
+}
+
+func (f *fakeCHProcess) IsRunning(pid int) bool {
+	return f.running[pid]
+}
+
+func (f *fakeCHProcess) Owns(pid int, _ string) bool {
+	return !f.notOwned[pid]
+}
+
+// newTestCHProvider reuses fakeNetworkManager and fakeRootfsPreparer from
+// fc_test.go: both are generic (NetworkManager/RootfsPreparer have nothing
+// Firecracker-specific about them), so there is no need for ch-specific
+// duplicates.
+func newTestCHProvider(t *testing.T) (ProviderCH, *fakeCHProcess, *fakeNetworkManager, *fakeRootfsPreparer) {
+	t.Helper()
+	proc := &fakeCHProcess{pid: 12345}
+	net := &fakeNetworkManager{}
+	rootfs := &fakeRootfsPreparer{}
+	p := ProviderCH{
+		Config: CHConfig{
+			KernelImage: "/images/vmlinux",
+			RootfsImage: "/images/rootfs.ext4",
+			VCPUCount:   1,
+			MemSizeMib:  512,
+			Bridge:      "chbr0",
+			CIDR:        "172.17.0.1/24",
+			Username:    "root",
+			StateDir:    t.TempDir(),
+		},
+		Process: proc,
+		Net:     net,
+		Rootfs:  rootfs,
+	}
+	return p, proc, net, rootfs
+}
+
+func TestParseCHType(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantVCPU int64
+		wantMem  int64
+	}{
+		{"", 1, 512},
+		{"2vcpu-1024mb", 2, 1024},
+		{"4VCPU-2048MB", 4, 2048},
+		{"garbage", 1, 512},
+		{"0vcpu-512mb", 1, 512},
+	}
+	for _, tt := range tests {
+		vcpu, mem := parseCHType(tt.in, 1, 512)
+		assert.Equal(t, tt.wantVCPU, vcpu, "vcpu for %q", tt.in)
+		assert.Equal(t, tt.wantMem, mem, "mem for %q", tt.in)
+	}
+}
+
+func TestCHTapName(t *testing.T) {
+	name := chTapName("my-test-vm")
+	assert.LessOrEqual(t, len(name), 15)
+	assert.True(t, strings.HasPrefix(name, "ch"))
+	assert.Equal(t, name, chTapName("my-test-vm"))
+	assert.NotEqual(t, name, chTapName("other-vm"))
+}
+
+func TestCHMAC(t *testing.T) {
+	mac := chMAC("my-test-vm")
+	assert.Regexp(t, `^02:CH:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}$`, mac)
+	assert.Equal(t, mac, chMAC("my-test-vm"))
+}
+
+func TestProviderCH_Deploy(t *testing.T) {
+	p, proc, netMgr, rootfs := newTestCHProvider(t)
+	pubKeyFile := writeTestPublicKey(t)
+
+	vm, err := p.Deploy(Vm{Name: "test-vm", SSHKeyID: pubKeyFile})
+	require.NoError(t, err)
+
+	assert.Equal(t, "ch", vm.Provider)
+	assert.Equal(t, "test-vm", vm.Name)
+	assert.Equal(t, "running", vm.Status)
+	assert.Equal(t, "1vcpu-512mb", vm.Type)
+	assert.Equal(t, "172.17.0.2", vm.IP)
+	assert.Equal(t, 1, proc.startCalls)
+	assert.Equal(t, []string{"chbr0"}, netMgr.bridges)
+	assert.Equal(t, []string{chTapName("test-vm")}, netMgr.taps)
+	assert.Len(t, rootfs.calls, 1)
+	assert.Equal(t, []string{"test-vm"}, rootfs.hostnames)
+
+	meta, err := loadCHMetadata(p.metadataPath("test-vm"))
+	require.NoError(t, err)
+	assert.Equal(t, 12345, meta.PID)
+	assert.Equal(t, "172.17.0.2", meta.IPAddress)
+	assert.Equal(t, chStatusRunning, meta.Status)
+}
+
+func TestProviderCH_Deploy_CustomType(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	vm, err := p.Deploy(Vm{Name: "big-vm", Type: "2vcpu-1024mb"})
+	require.NoError(t, err)
+	assert.Equal(t, "2vcpu-1024mb", vm.Type)
+}
+
+func TestProviderCH_Deploy_Idempotent(t *testing.T) {
+	p, proc, _, _ := newTestCHProvider(t)
+
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, proc.startCalls)
+
+	vm2, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, "test-vm", vm2.Name)
+	assert.Equal(t, 1, proc.startCalls)
+}
+
+func TestProviderCH_Deploy_MissingImages(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	p.Config.KernelImage = ""
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	assert.Error(t, err)
+}
+
+func TestProviderCH_Deploy_StartFailureCleansUp(t *testing.T) {
+	p, proc, netMgr, _ := newTestCHProvider(t)
+	proc.startErr = errors.New("boom")
+
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	assert.Error(t, err)
+	assert.Contains(t, netMgr.deleted, chTapName("test-vm"))
+
+	_, statErr := os.Stat(p.vmDir("test-vm"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestProviderCH_List_ReconcilesDeadProcess verifies that List() does not
+// keep reporting a microVM as running once its cloud-hypervisor process is
+// gone out-of-band (e.g. the host rebooted).
+func TestProviderCH_List_ReconcilesDeadProcess(t *testing.T) {
+	p, proc, _, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	running, err := p.List()
+	require.NoError(t, err)
+	require.Len(t, running.List, 1)
+	assert.Equal(t, chStatusRunning, running.List[0].Status)
+
+	// Simulate a host reboot: the cloud-hypervisor process is gone.
+	proc.running = map[int]bool{}
+
+	running, err = p.List()
+	require.NoError(t, err)
+	require.Len(t, running.List, 1, "a dead microVM is still surfaced, just with an honest status")
+	assert.Equal(t, chStatusDead, running.List[0].Status)
+
+	meta, err := loadCHMetadata(p.metadataPath("test-vm"))
+	require.NoError(t, err)
+	assert.Equal(t, chStatusDead, meta.Status, "status should self-heal on disk")
+}
+
+// TestProviderCH_Deploy_RecreatesStaleRecord verifies that Deploy() does not
+// silently no-op when a same-named microVM's record exists but its process
+// is dead — it should clean up the stale state and boot a fresh microVM.
+func TestProviderCH_Deploy_RecreatesStaleRecord(t *testing.T) {
+	p, proc, netMgr, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, proc.startCalls)
+
+	proc.running = map[int]bool{}
+
+	vm, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, proc.startCalls, "Deploy should recreate a stale microVM instead of no-op'ing")
+	assert.Equal(t, chStatusRunning, vm.Status)
+	assert.Contains(t, netMgr.deleted, chTapName("test-vm"), "the stale tap device should be cleaned up")
+}
+
+func TestProviderCH_GetByName_ReconcilesDeadProcess(t *testing.T) {
+	p, proc, _, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	proc.running = map[int]bool{}
+
+	vm, err := p.GetByName("test-vm")
+	require.NoError(t, err)
+	assert.Equal(t, chStatusDead, vm.Status)
+}
+
+func TestProviderCH_GetByName_NotFound(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	vm, err := p.GetByName("nope")
+	require.NoError(t, err)
+	assert.Equal(t, Vm{}, vm)
+}
+
+func TestProviderCH_Destroy(t *testing.T) {
+	p, proc, netMgr, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Destroy(Vm{Name: "test-vm"}))
+	assert.Contains(t, proc.stopCalls, 12345)
+	assert.Contains(t, netMgr.deleted, chTapName("test-vm"))
+
+	_, statErr := os.Stat(p.vmDir("test-vm"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// TestProviderCH_Destroy_StalePID verifies that Destroy does not signal a
+// running process whose PID was persisted for this microVM but no longer
+// belongs to it (e.g. reused after a host reboot).
+func TestProviderCH_Destroy_StalePID(t *testing.T) {
+	p, proc, netMgr, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+	proc.notOwned = map[int]bool{12345: true}
+
+	require.NoError(t, p.Destroy(Vm{Name: "test-vm"}))
+	assert.NotContains(t, proc.stopCalls, 12345)
+	assert.Contains(t, netMgr.deleted, chTapName("test-vm"))
+
+	_, statErr := os.Stat(p.vmDir("test-vm"))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestProviderCH_Destroy_NotFound(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	assert.Error(t, p.Destroy(Vm{Name: "nope"}))
+}
+
+func TestProviderCH_PauseResumeUnsupported(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	assert.ErrorIs(t, p.Pause(Vm{Name: "test-vm"}, true), errChUnsupported)
+	_, err := p.Resume(Vm{Name: "test-vm"})
+	assert.ErrorIs(t, err, errChUnsupported)
+
+	paused, err := p.ListPaused()
+	require.NoError(t, err)
+	assert.Empty(t, paused.List)
+}
+
+func TestProviderCH_CreateSSHKey(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	keyFile := writeTestPublicKey(t)
+
+	keyID, err := p.CreateSSHKey(keyFile)
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(keyID))
+}
+
+func TestProviderCH_CreateSSHKey_Invalid(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	keyFile := filepath.Join(t.TempDir(), "bad.pub")
+	require.NoError(t, os.WriteFile(keyFile, []byte("not a key"), 0644))
+
+	_, err := p.CreateSSHKey(keyFile)
+	assert.Error(t, err)
+}

--- a/pkg/cloud/ch_test.go
+++ b/pkg/cloud/ch_test.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,8 +104,12 @@ func TestCHTapName(t *testing.T) {
 
 func TestCHMAC(t *testing.T) {
 	mac := chMAC("my-test-vm")
-	assert.Regexp(t, `^02:CH:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}$`, mac)
+	assert.Regexp(t, `^02:C4:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}$`, mac)
 	assert.Equal(t, mac, chMAC("my-test-vm"))
+	// Regression check for a bug caught in review: every octet must be
+	// valid hex, or Cloud Hypervisor rejects the vm.create payload outright.
+	_, err := net.ParseMAC(mac)
+	assert.NoError(t, err)
 }
 
 func TestProviderCH_Deploy(t *testing.T) {

--- a/pkg/cloud/pause_resume_test.go
+++ b/pkg/cloud/pause_resume_test.go
@@ -23,6 +23,7 @@ func TestAllProvidersImplementPauseResume(t *testing.T) {
 		"azure":   ProviderAzure{},
 		"gcp":     ProviderGcp{},
 		"fc":      ProviderFC{},
+		"ch":      ProviderCH{},
 	}
 	for name, p := range providers {
 		if _, ok := p.(CloudProviderInterface); !ok {


### PR DESCRIPTION
## Summary
- Adds a new `ch` provider that runs local [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) microVMs (Linux + KVM, no cloud account needed), mirroring the existing `fc` (Firecracker) provider's architecture: host-local state under `/opt/ch`, bridge/TAP networking, and debugfs-based rootfs prep (hostname + SSH key injection).
- Cloud Hypervisor's REST API differs from Firecracker's (single `PUT /vm.create` + `PUT /vm.boot` vs Firecracker's per-resource PUTs), so `internal/providerch` talks to it directly rather than reusing `providerfc`.
- MVP scope: `create`/`destroy`/`ls`/`ssh` only. `pause`/`resume` return a clear "not supported" error (no snapshot support yet), matching the existing `static` provider's convention for unsupported operations.
- New flags: `--ch-kernel-image`, `--ch-rootfs-image`, `--ch-binary` (separate from `fc`'s equivalents since their defaults point at different image directories); `--vcpu`/`--memory`/`--username` are shared with `fc`.
- `internal/files/init/onctl.yaml` gets a `ch:` config section; `README.md` gets a one-line mention.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `golangci-lint run ./...` all clean
- [x] New `pkg/cloud/ch_test.go` covers deploy/destroy/idempotency/stale-process reconciliation/SSH key validation (mirrors `fc_test.go`, reusing its generic `fakeNetworkManager`/`fakeRootfsPreparer` doubles)
- [x] `TestAllProvidersImplementPauseResume` and `TestCloudProviderList` updated to include `ch`
- [ ] Manual smoke test on a Linux+KVM host with a real `cloud-hypervisor` binary + kernel/rootfs images (not done in this environment — macOS, no KVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx5i19SzjoDPrn1eccMzCe