### PR TITLE
Fix stale /etc/hosts breaking VNC on desktop-image VMs

### DIFF
--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -753,24 +753,32 @@ func rewriteEtcHosts(hosts []byte, hostname string) []byte {
 // requests runDebugfsScript issues, this never modifies the image, so it
 // doesn't need -w.
 //
-// It first confirms path is a plain regular file via a "stat" request,
-// rather than trying to infer that from how "dump" itself behaves:
-// dump doesn't fail (nonzero exit) on a missing path, it just leaves the
-// output empty; and on a symlink, debugfs 1.47 doesn't follow it either,
-// silently leaving a short/empty read instead of erroring. Both look
-// identical to a legitimately empty regular file after the fact, so
-// there's no reliable way to tell them apart from dump's own output --
-// but a caller like injectHostname, which uses this to read-then-rewrite,
-// absolutely needs to: rewriting a symlinked /etc/hosts as if it read
-// empty would silently replace the symlink with a plain file, discarding
-// whatever it pointed to. Checking the type up front with "stat" avoids
-// ever reaching that rewrite for anything but a real regular file.
+// It first checks path's type via a "stat" request, rather than trying to
+// infer that from how "dump" itself behaves: dump doesn't fail (nonzero
+// exit) on a missing path, it just leaves the output empty; and on a
+// symlink, debugfs 1.47 doesn't follow it either, silently leaving a
+// short/empty read instead of erroring. Both look identical to a
+// legitimately empty regular file after the fact, so there's no reliable
+// way to tell them apart from dump's own output -- but a caller like
+// injectHostname, which uses this to read-then-rewrite, needs to for the
+// symlink case: rewriting a symlinked /etc/hosts as if it read empty
+// would silently replace the symlink with a plain file, discarding
+// whatever it pointed to. A confirmed-missing path is different: unlike a
+// symlink, there's nothing there to accidentally clobber, and a minimal
+// rootfs with no /etc/hosts at all worked fine before injectHostname ever
+// touched this file, so that case returns (nil, nil) -- empty content,
+// not an error -- letting the caller's write/sif commands create it fresh
+// exactly as they've always created /etc/hostname.
 func readDebugfsFile(rootfsPath, path string) ([]byte, error) {
 	statOut, err := exec.Command("debugfs", "-R", "stat "+path, rootfsPath).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("debugfs failed (stat): %w: %s", err, strings.TrimSpace(string(statOut)))
 	}
-	if !strings.Contains(strings.ToLower(string(statOut)), "type: regular") {
+	lowerStat := strings.ToLower(string(statOut))
+	if strings.Contains(lowerStat, "not found") {
+		return nil, nil
+	}
+	if !strings.Contains(lowerStat, "type: regular") {
 		return nil, fmt.Errorf("%s is not a plain regular file in this image, refusing to read/rewrite it: %s", path, strings.TrimSpace(string(statOut)))
 	}
 

--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -752,7 +752,28 @@ func rewriteEtcHosts(hosts []byte, hostname string) []byte {
 // rootfsPath via debugfs's "dump" request -- unlike the write/rm/sif
 // requests runDebugfsScript issues, this never modifies the image, so it
 // doesn't need -w.
+//
+// It first confirms path is a plain regular file via a "stat" request,
+// rather than trying to infer that from how "dump" itself behaves:
+// dump doesn't fail (nonzero exit) on a missing path, it just leaves the
+// output empty; and on a symlink, debugfs 1.47 doesn't follow it either,
+// silently leaving a short/empty read instead of erroring. Both look
+// identical to a legitimately empty regular file after the fact, so
+// there's no reliable way to tell them apart from dump's own output --
+// but a caller like injectHostname, which uses this to read-then-rewrite,
+// absolutely needs to: rewriting a symlinked /etc/hosts as if it read
+// empty would silently replace the symlink with a plain file, discarding
+// whatever it pointed to. Checking the type up front with "stat" avoids
+// ever reaching that rewrite for anything but a real regular file.
 func readDebugfsFile(rootfsPath, path string) ([]byte, error) {
+	statOut, err := exec.Command("debugfs", "-R", "stat "+path, rootfsPath).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("debugfs failed (stat): %w: %s", err, strings.TrimSpace(string(statOut)))
+	}
+	if !strings.Contains(strings.ToLower(string(statOut)), "type: regular") {
+		return nil, fmt.Errorf("%s is not a plain regular file in this image, refusing to read/rewrite it: %s", path, strings.TrimSpace(string(statOut)))
+	}
+
 	dumpFile, err := os.CreateTemp("", "onctl-debugfs-dump-*")
 	if err != nil {
 		return nil, err
@@ -763,20 +784,8 @@ func readDebugfsFile(rootfsPath, path string) ([]byte, error) {
 	}
 
 	req := fmt.Sprintf("dump %s %s", path, dumpFile.Name())
-	out, err := exec.Command("debugfs", "-R", req, rootfsPath).CombinedOutput()
-	if err != nil {
+	if out, err := exec.Command("debugfs", "-R", req, rootfsPath).CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("debugfs failed (dump): %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	// debugfs's "dump" request doesn't itself fail (nonzero exit) when the
-	// requested path doesn't exist in the image -- it just prints a
-	// diagnostic like "<path>: File not found by ext2_lookup" to stdout
-	// and leaves the output file empty. Catch that case by its message
-	// rather than by an empty result, since a *present* file can
-	// legitimately be zero bytes too (e.g. a minimal/custom rootfs with an
-	// empty /etc/hosts) -- treating "empty" as "missing" would wrongly
-	// abort Prepare for those.
-	if strings.Contains(strings.ToLower(string(out)), "not found") {
-		return nil, fmt.Errorf("debugfs dump of %s reported it doesn't exist in this image: %s", path, strings.TrimSpace(string(out)))
 	}
 	return os.ReadFile(dumpFile.Name())
 }

--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -763,22 +763,22 @@ func readDebugfsFile(rootfsPath, path string) ([]byte, error) {
 	}
 
 	req := fmt.Sprintf("dump %s %s", path, dumpFile.Name())
-	if out, err := exec.Command("debugfs", "-R", req, rootfsPath).CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("debugfs failed (dump): %w: %s", err, strings.TrimSpace(string(out)))
-	}
-	content, err := os.ReadFile(dumpFile.Name())
+	out, err := exec.Command("debugfs", "-R", req, rootfsPath).CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("debugfs failed (dump): %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	// debugfs's "dump" request doesn't itself fail (nonzero exit) when the
 	// requested path doesn't exist in the image -- it just prints a
-	// message and leaves the output file empty. Treat that as an error
-	// rather than silently handing back zero bytes: injectHostname's
-	// caller would otherwise happily write an (almost) empty /etc/hosts.
-	if len(content) == 0 {
-		return nil, fmt.Errorf("debugfs dump of %s produced no output -- does it exist in this image?", path)
+	// diagnostic like "<path>: File not found by ext2_lookup" to stdout
+	// and leaves the output file empty. Catch that case by its message
+	// rather than by an empty result, since a *present* file can
+	// legitimately be zero bytes too (e.g. a minimal/custom rootfs with an
+	// empty /etc/hosts) -- treating "empty" as "missing" would wrongly
+	// abort Prepare for those.
+	if strings.Contains(strings.ToLower(string(out)), "not found") {
+		return nil, fmt.Errorf("debugfs dump of %s reported it doesn't exist in this image: %s", path, strings.TrimSpace(string(out)))
 	}
-	return content, nil
+	return os.ReadFile(dumpFile.Name())
 }
 
 // runDebugfsScript writes script to a temp file and runs `debugfs -w` with

--- a/internal/providerfc/common.go
+++ b/internal/providerfc/common.go
@@ -675,12 +675,21 @@ func injectSSHKey(rootfsPath, publicKey, username string) error {
 	return runDebugfsScript(rootfsPath, script)
 }
 
-// injectHostname writes hostname to /etc/hostname inside the ext-family
-// image at rootfsPath using debugfs, without mounting the image. The baked
-// base image always carries the same placeholder hostname (bake-fc-image.sh
-// runs debootstrap in a chroot, which can't isolate the UTS namespace, so it
-// bakes in a fixed value) — this gives each VM's per-VM rootfs copy its own,
-// matching the name onctl created it with.
+// injectHostname writes hostname to /etc/hostname, and updates /etc/hosts'
+// 127.0.1.1 entry to match, inside the ext-family image at rootfsPath using
+// debugfs, without mounting the image. 127.0.1.1 (not 127.0.0.1, which
+// stays reserved for "localhost" itself) is the Debian/Ubuntu convention
+// for a machine's own hostname-to-loopback mapping. The baked base image
+// always carries the same placeholder hostname, in both files (
+// bake-fc-image.sh runs debootstrap in a chroot, which can't isolate the
+// UTS namespace, so it bakes in a fixed value) — this gives each VM's
+// per-VM rootfs copy its own of both, matching the name onctl created it
+// with. Leaving /etc/hosts stale (as a prior version of this function did,
+// touching only /etc/hostname) breaks anything that resolves its own FQDN
+// via getaddrinfo once the live hostname no longer matches any /etc/hosts
+// entry — e.g. the desktop image's TigerVNC vncserver script, which
+// refuses to start ("Could not acquire fully qualified host name of this
+// machine") in exactly that state.
 func injectHostname(rootfsPath, hostname string) error {
 	hostnameFile, err := os.CreateTemp("", "onctl-hostname-*")
 	if err != nil {
@@ -695,11 +704,81 @@ func injectHostname(rootfsPath, hostname string) error {
 		return err
 	}
 
+	hostsContent, err := readDebugfsFile(rootfsPath, "/etc/hosts")
+	if err != nil {
+		return fmt.Errorf("failed to read /etc/hosts: %w", err)
+	}
+
+	hostsFile, err := os.CreateTemp("", "onctl-hosts-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(hostsFile.Name()) }()
+	if _, err := hostsFile.Write(rewriteEtcHosts(hostsContent, hostname)); err != nil {
+		_ = hostsFile.Close()
+		return err
+	}
+	if err := hostsFile.Close(); err != nil {
+		return err
+	}
+
 	script := fmt.Sprintf(
-		"rm /etc/hostname\nwrite %s /etc/hostname\nsif /etc/hostname mode 0100644\n",
-		hostnameFile.Name(),
+		"rm /etc/hostname\nwrite %s /etc/hostname\nsif /etc/hostname mode 0100644\n"+
+			"rm /etc/hosts\nwrite %s /etc/hosts\nsif /etc/hosts mode 0100644\n",
+		hostnameFile.Name(), hostsFile.Name(),
 	)
 	return runDebugfsScript(rootfsPath, script)
+}
+
+// rewriteEtcHosts replaces hosts' 127.0.1.1 line (see injectHostname's doc
+// comment) with one pointing at hostname, or appends that line if none
+// exists (some base images may not carry one at all).
+func rewriteEtcHosts(hosts []byte, hostname string) []byte {
+	lines := strings.Split(strings.TrimRight(string(hosts), "\n"), "\n")
+	replaced := false
+	for i, line := range lines {
+		if fields := strings.Fields(line); len(fields) > 0 && fields[0] == "127.0.1.1" {
+			lines[i] = "127.0.1.1\t" + hostname
+			replaced = true
+		}
+	}
+	if !replaced {
+		lines = append(lines, "127.0.1.1\t"+hostname)
+	}
+	return []byte(strings.Join(lines, "\n") + "\n")
+}
+
+// readDebugfsFile reads path's content out of the ext-family image at
+// rootfsPath via debugfs's "dump" request -- unlike the write/rm/sif
+// requests runDebugfsScript issues, this never modifies the image, so it
+// doesn't need -w.
+func readDebugfsFile(rootfsPath, path string) ([]byte, error) {
+	dumpFile, err := os.CreateTemp("", "onctl-debugfs-dump-*")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = os.Remove(dumpFile.Name()) }()
+	if err := dumpFile.Close(); err != nil {
+		return nil, err
+	}
+
+	req := fmt.Sprintf("dump %s %s", path, dumpFile.Name())
+	if out, err := exec.Command("debugfs", "-R", req, rootfsPath).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("debugfs failed (dump): %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	content, err := os.ReadFile(dumpFile.Name())
+	if err != nil {
+		return nil, err
+	}
+	// debugfs's "dump" request doesn't itself fail (nonzero exit) when the
+	// requested path doesn't exist in the image -- it just prints a
+	// message and leaves the output file empty. Treat that as an error
+	// rather than silently handing back zero bytes: injectHostname's
+	// caller would otherwise happily write an (almost) empty /etc/hosts.
+	if len(content) == 0 {
+		return nil, fmt.Errorf("debugfs dump of %s produced no output -- does it exist in this image?", path)
+	}
+	return content, nil
 }
 
 // runDebugfsScript writes script to a temp file and runs `debugfs -w` with

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -580,6 +580,53 @@ func TestRewriteEtcHosts(t *testing.T) {
 	})
 }
 
+// installFakeDebugfsDump puts a fake `debugfs` binary on PATH that only
+// answers a `-R "dump <path> <outfile>"` request: it writes fileContent to
+// <outfile> and prints stdout, always exiting 0 -- for exercising
+// readDebugfsFile's success-vs-"not found" distinction without a real
+// debugfs binary or ext4 image.
+func installFakeDebugfsDump(t *testing.T, stdout string, fileContent []byte) {
+	t.Helper()
+	binDir := t.TempDir()
+	contentFile := filepath.Join(binDir, "content")
+	require.NoError(t, os.WriteFile(contentFile, fileContent, 0644))
+	stdoutFile := filepath.Join(binDir, "stdout")
+	require.NoError(t, os.WriteFile(stdoutFile, []byte(stdout), 0644))
+	script := fmt.Sprintf(
+		"#!/bin/sh\n"+
+			"out=$(echo \"$2\" | awk '{print $3}')\n"+
+			"cp %q \"$out\"\n"+
+			"cat %q\n"+
+			"exit 0\n",
+		contentFile, stdoutFile,
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "debugfs"), []byte(script), 0755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestReadDebugfsFile(t *testing.T) {
+	t.Run("accepts a legitimately empty file", func(t *testing.T) {
+		installFakeDebugfsDump(t, "", []byte{})
+		content, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
+		require.NoError(t, err)
+		assert.Empty(t, content)
+	})
+
+	t.Run("rejects a path debugfs reports missing", func(t *testing.T) {
+		installFakeDebugfsDump(t, "/etc/hosts: File not found by ext2_lookup\n", []byte{})
+		_, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "doesn't exist in this image")
+	})
+
+	t.Run("returns real content on success", func(t *testing.T) {
+		installFakeDebugfsDump(t, "", []byte("127.0.0.1\tlocalhost\n"))
+		content, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
+		require.NoError(t, err)
+		assert.Equal(t, "127.0.0.1\tlocalhost\n", string(content))
+	})
+}
+
 func TestDebugfsRootfsPreparer_Prepare_HostnameDebugfsFails(t *testing.T) {
 	dir := t.TempDir()
 	src := filepath.Join(dir, "base.ext4")

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -72,25 +72,30 @@ func startUnixServer(t *testing.T, sock string, mux *http.ServeMux) {
 
 // installFakeDebugfs puts a fake `debugfs` binary on PATH that copies the
 // script file it's given (its 3rd argument, from `-f <script>`) to
-// recordPath and exits with exitCode. A `-R "dump <path> <outfile>"`
-// invocation (readDebugfsFile's read-only request, e.g. injectHostname
-// reading /etc/hosts before rewriting it) is handled specially: rather
-// than being recorded, it's answered with a small stand-in /etc/hosts so
-// callers that both read and then write via this same fake (like
-// injectHostname) see realistic content to rewrite.
+// recordPath and exits with exitCode. readDebugfsFile's two read-only `-R`
+// requests (e.g. injectHostname reading /etc/hosts before rewriting it)
+// are handled specially, rather than being recorded: `stat <path>` is
+// answered as a plain regular file, and `dump <path> <outfile>` is
+// answered with a small stand-in /etc/hosts, so callers that both read and
+// then write via this same fake (like injectHostname) see realistic
+// content to rewrite.
 func installFakeDebugfs(t *testing.T, recordPath string, exitCode int) {
 	t.Helper()
 	binDir := t.TempDir()
 	script := fmt.Sprintf(
 		"#!/bin/sh\n"+
 			"if [ \"$1\" = \"-R\" ]; then\n"+
-			"  out=$(echo \"$2\" | awk '{print $3}')\n"+
-			"  printf '127.0.0.1\\tlocalhost\\n::1\\t\\tlocalhost ip6-localhost ip6-loopback\\n127.0.1.1\\tfc-base\\n' > \"$out\"\n"+
-			"  exit %d\n"+
+			"  case \"$2\" in\n"+
+			"    \"stat \"*) printf 'Type: regular    Mode:  0644\\n'; exit %d ;;\n"+
+			"    \"dump \"*)\n"+
+			"      out=$(echo \"$2\" | awk '{print $3}')\n"+
+			"      printf '127.0.0.1\\tlocalhost\\n::1\\t\\tlocalhost ip6-localhost ip6-loopback\\n127.0.1.1\\tfc-base\\n' > \"$out\"\n"+
+			"      exit %d ;;\n"+
+			"  esac\n"+
 			"fi\n"+
 			"cat \"$3\" > %q\n"+
 			"exit %d\n",
-		exitCode, recordPath, exitCode,
+		exitCode, exitCode, recordPath, exitCode,
 	)
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "debugfs"), []byte(script), 0755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -580,33 +585,37 @@ func TestRewriteEtcHosts(t *testing.T) {
 	})
 }
 
-// installFakeDebugfsDump puts a fake `debugfs` binary on PATH that only
-// answers a `-R "dump <path> <outfile>"` request: it writes fileContent to
-// <outfile> and prints stdout, always exiting 0 -- for exercising
-// readDebugfsFile's success-vs-"not found" distinction without a real
-// debugfs binary or ext4 image.
-func installFakeDebugfsDump(t *testing.T, stdout string, fileContent []byte) {
+// installFakeDebugfsDump puts a fake `debugfs` binary on PATH that answers
+// readDebugfsFile's two `-R` requests: `stat <path>` (replies with
+// statOutput, always exiting 0) and `dump <path> <outfile>` (writes
+// fileContent to <outfile>, always exiting 0) -- for exercising
+// readDebugfsFile's type-check-then-read flow without a real debugfs
+// binary or ext4 image.
+func installFakeDebugfsDump(t *testing.T, statOutput string, fileContent []byte) {
 	t.Helper()
 	binDir := t.TempDir()
 	contentFile := filepath.Join(binDir, "content")
 	require.NoError(t, os.WriteFile(contentFile, fileContent, 0644))
-	stdoutFile := filepath.Join(binDir, "stdout")
-	require.NoError(t, os.WriteFile(stdoutFile, []byte(stdout), 0644))
+	statFile := filepath.Join(binDir, "stat-output")
+	require.NoError(t, os.WriteFile(statFile, []byte(statOutput), 0644))
 	script := fmt.Sprintf(
 		"#!/bin/sh\n"+
-			"out=$(echo \"$2\" | awk '{print $3}')\n"+
-			"cp %q \"$out\"\n"+
-			"cat %q\n"+
-			"exit 0\n",
-		contentFile, stdoutFile,
+			"case \"$2\" in\n"+
+			"  \"stat \"*) cat %q; exit 0 ;;\n"+
+			"  \"dump \"*)\n"+
+			"    out=$(echo \"$2\" | awk '{print $3}')\n"+
+			"    cp %q \"$out\"\n"+
+			"    exit 0 ;;\n"+
+			"esac\n",
+		statFile, contentFile,
 	)
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "debugfs"), []byte(script), 0755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestReadDebugfsFile(t *testing.T) {
-	t.Run("accepts a legitimately empty file", func(t *testing.T) {
-		installFakeDebugfsDump(t, "", []byte{})
+	t.Run("accepts a legitimately empty regular file", func(t *testing.T) {
+		installFakeDebugfsDump(t, "Type: regular    Mode:  0644\n", []byte{})
 		content, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
 		require.NoError(t, err)
 		assert.Empty(t, content)
@@ -616,11 +625,18 @@ func TestReadDebugfsFile(t *testing.T) {
 		installFakeDebugfsDump(t, "/etc/hosts: File not found by ext2_lookup\n", []byte{})
 		_, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "doesn't exist in this image")
+		assert.Contains(t, err.Error(), "refusing to read/rewrite")
+	})
+
+	t.Run("rejects a symlink rather than silently truncating it", func(t *testing.T) {
+		installFakeDebugfsDump(t, "Type: symlink    Mode:  0777\n", []byte{})
+		_, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to read/rewrite")
 	})
 
 	t.Run("returns real content on success", func(t *testing.T) {
-		installFakeDebugfsDump(t, "", []byte("127.0.0.1\tlocalhost\n"))
+		installFakeDebugfsDump(t, "Type: regular    Mode:  0644\n", []byte("127.0.0.1\tlocalhost\n"))
 		content, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
 		require.NoError(t, err)
 		assert.Equal(t, "127.0.0.1\tlocalhost\n", string(content))

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -72,11 +72,26 @@ func startUnixServer(t *testing.T, sock string, mux *http.ServeMux) {
 
 // installFakeDebugfs puts a fake `debugfs` binary on PATH that copies the
 // script file it's given (its 3rd argument, from `-f <script>`) to
-// recordPath and exits with exitCode.
+// recordPath and exits with exitCode. A `-R "dump <path> <outfile>"`
+// invocation (readDebugfsFile's read-only request, e.g. injectHostname
+// reading /etc/hosts before rewriting it) is handled specially: rather
+// than being recorded, it's answered with a small stand-in /etc/hosts so
+// callers that both read and then write via this same fake (like
+// injectHostname) see realistic content to rewrite.
 func installFakeDebugfs(t *testing.T, recordPath string, exitCode int) {
 	t.Helper()
 	binDir := t.TempDir()
-	script := fmt.Sprintf("#!/bin/sh\ncat \"$3\" > %q\nexit %d\n", recordPath, exitCode)
+	script := fmt.Sprintf(
+		"#!/bin/sh\n"+
+			"if [ \"$1\" = \"-R\" ]; then\n"+
+			"  out=$(echo \"$2\" | awk '{print $3}')\n"+
+			"  printf '127.0.0.1\\tlocalhost\\n::1\\t\\tlocalhost ip6-localhost ip6-loopback\\n127.0.1.1\\tfc-base\\n' > \"$out\"\n"+
+			"  exit %d\n"+
+			"fi\n"+
+			"cat \"$3\" > %q\n"+
+			"exit %d\n",
+		exitCode, recordPath, exitCode,
+	)
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "debugfs"), []byte(script), 0755))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
@@ -537,6 +552,32 @@ func TestDebugfsRootfsPreparer_Prepare_InjectsHostname(t *testing.T) {
 	assert.Contains(t, string(script), "write ")
 	assert.Contains(t, string(script), " /etc/hostname\n")
 	assert.Contains(t, string(script), "sif /etc/hostname mode 0100644\n")
+	// The stale 127.0.1.1 entry needs rewriting too (see injectHostname's
+	// doc comment) -- not just /etc/hostname -- or the new hostname won't
+	// resolve its own FQDN via /etc/hosts at all.
+	assert.Contains(t, string(script), "rm /etc/hosts\n")
+	assert.Contains(t, string(script), " /etc/hosts\n")
+	assert.Contains(t, string(script), "sif /etc/hosts mode 0100644\n")
+}
+
+func TestRewriteEtcHosts(t *testing.T) {
+	t.Run("replaces the 127.0.1.1 line, keeping everything else", func(t *testing.T) {
+		in := "127.0.0.1\tlocalhost\n" +
+			"::1\t\tlocalhost ip6-localhost ip6-loopback\n" +
+			"127.0.1.1\tboxctl-desktop\n"
+		out := string(rewriteEtcHosts([]byte(in), "gh-runner-12345"))
+		assert.Contains(t, out, "127.0.0.1\tlocalhost\n")
+		assert.Contains(t, out, "::1\t\tlocalhost ip6-localhost ip6-loopback\n")
+		assert.Contains(t, out, "127.0.1.1\tgh-runner-12345\n")
+		assert.NotContains(t, out, "boxctl-desktop")
+	})
+
+	t.Run("appends a 127.0.1.1 line when none exists", func(t *testing.T) {
+		in := "127.0.0.1\tlocalhost\n"
+		out := string(rewriteEtcHosts([]byte(in), "gh-runner-12345"))
+		assert.Contains(t, out, "127.0.0.1\tlocalhost\n")
+		assert.Contains(t, out, "127.0.1.1\tgh-runner-12345\n")
+	})
 }
 
 func TestDebugfsRootfsPreparer_Prepare_HostnameDebugfsFails(t *testing.T) {

--- a/internal/providerfc/common_test.go
+++ b/internal/providerfc/common_test.go
@@ -565,6 +565,47 @@ func TestDebugfsRootfsPreparer_Prepare_InjectsHostname(t *testing.T) {
 	assert.Contains(t, string(script), "sif /etc/hosts mode 0100644\n")
 }
 
+// installFakeDebugfsNoHosts puts a fake `debugfs` binary on PATH whose
+// `-R "stat <path>"` always reports the path missing, for
+// TestDebugfsRootfsPreparer_Prepare_CreatesHostsWhenMissing -- a minimal
+// rootfs with no /etc/hosts at all, which must not abort Prepare.
+func installFakeDebugfsNoHosts(t *testing.T, recordPath string) {
+	t.Helper()
+	binDir := t.TempDir()
+	script := fmt.Sprintf(
+		"#!/bin/sh\n"+
+			"if [ \"$1\" = \"-R\" ]; then\n"+
+			"  case \"$2\" in\n"+
+			"    \"stat \"*) printf '%%s: File not found by ext2_lookup\\n' \"$2\"; exit 0 ;;\n"+
+			"  esac\n"+
+			"fi\n"+
+			"cat \"$3\" > %q\n"+
+			"exit 0\n",
+		recordPath,
+	)
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "debugfs"), []byte(script), 0755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestDebugfsRootfsPreparer_Prepare_CreatesHostsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "base.ext4")
+	dst := filepath.Join(dir, "rootfs.ext4")
+	require.NoError(t, os.WriteFile(src, []byte("image-data"), 0644))
+
+	calls := filepath.Join(dir, "debugfs-calls.txt")
+	installFakeDebugfsNoHosts(t, calls)
+
+	p := NewRootfsPreparer()
+	require.NoError(t, p.Prepare(src, dst, "gh-runner-12345", "", "root"))
+
+	script, err := os.ReadFile(calls)
+	require.NoError(t, err)
+	assert.Contains(t, string(script), "rm /etc/hosts\n")
+	assert.Contains(t, string(script), " /etc/hosts\n")
+	assert.Contains(t, string(script), "sif /etc/hosts mode 0100644\n")
+}
+
 func TestRewriteEtcHosts(t *testing.T) {
 	t.Run("replaces the 127.0.1.1 line, keeping everything else", func(t *testing.T) {
 		in := "127.0.0.1\tlocalhost\n" +
@@ -621,11 +662,15 @@ func TestReadDebugfsFile(t *testing.T) {
 		assert.Empty(t, content)
 	})
 
-	t.Run("rejects a path debugfs reports missing", func(t *testing.T) {
+	t.Run("treats a confirmed-missing path as empty, not an error", func(t *testing.T) {
+		// A minimal/custom rootfs with no /etc/hosts at all worked fine
+		// before injectHostname ever touched this file -- unlike a
+		// symlink, there's nothing here to accidentally clobber, so this
+		// must let the caller create it fresh rather than aborting Prepare.
 		installFakeDebugfsDump(t, "/etc/hosts: File not found by ext2_lookup\n", []byte{})
-		_, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "refusing to read/rewrite")
+		content, err := readDebugfsFile("irrelevant-rootfs-path", "/etc/hosts")
+		require.NoError(t, err)
+		assert.Empty(t, content)
 	})
 
 	t.Run("rejects a symlink rather than silently truncating it", func(t *testing.T) {


### PR DESCRIPTION
injectHostname rewrote /etc/hostname to each VM's own name at deploy time but left /etc/hosts' 127.0.1.1 entry pointing at the image's baked placeholder, so the two no longer matched. TigerVNC's vncserver script resolves its own FQDN on startup and refuses to run once that lookup fails ("Could not acquire fully qualified host name of this machine"), crash-looping vncserver@1.service on every desktop-image VM.

injectHostname now reads /etc/hosts out of the image via debugfs's non-destructive dump request and rewrites its 127.0.1.1 line to match, in the same rm/write/sif pass as /etc/hostname.


Claude-Session: https://claude.ai/code/session_01XUUwyWgX4uLP4grY6kxZWj