### PR TITLE
Swap dead Go Report Card badge for a Lint one

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check 🌍 https://docs.onctl.io for detailed documentation
 [![build](https://github.com/cdalar/onctl/actions/workflows/build.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/build.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cdalar/onctl/badge)](https://scorecard.dev/viewer/?uri=github.com/cdalar/onctl)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10052/badge)](https://www.bestpractices.dev/projects/10052)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cdalar/onctl)](https://goreportcard.com/report/github.com/cdalar/onctl)
+[![Lint](https://github.com/cdalar/onctl/actions/workflows/lint.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/lint.yml)
 [![CodeQL](https://github.com/cdalar/onctl/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/github-code-scanning/codeql)
 [![codecov](https://codecov.io/gh/cdalar/onctl/graph/badge.svg?token=7VU7H1II09)](https://codecov.io/gh/cdalar/onctl)
 [![Github All Releases](https://img.shields.io/github/downloads/cdalar/onctl/total.svg)]()

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 Check 🌍 https://docs.onctl.io for detailed documentation
 
 [![build](https://github.com/cdalar/onctl/actions/workflows/build.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/build.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/cdalar/onctl)](https://goreportcard.com/report/github.com/cdalar/onctl)
+[![Lint](https://github.com/cdalar/onctl/actions/workflows/lint.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/lint.yml)
 [![CodeQL](https://github.com/cdalar/onctl/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/github-code-scanning/codeql)
 [![codecov](https://codecov.io/gh/cdalar/onctl/graph/badge.svg?token=7VU7H1II09)](https://codecov.io/gh/cdalar/onctl)
 ![Github All Releases](https://img.shields.io/github/downloads/cdalar/onctl/total.svg)


### PR DESCRIPTION
## Summary
- Go Report Card has been sunset (see https://goreportcard.com/report/github.com/cdalar/onctl) and its own announcement names `golangci-lint` as the successor
- This repo already runs `golangci-lint` in CI (`.github/workflows/lint.yml`), so swap the now-dead badge for one pointing at that workflow instead

## Test plan
- [x] Badge markdown renders the same way as the existing `build` badge (same GitHub Actions badge.svg pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUUwyWgX4uLP4grY6kxZWj