### PR TITLE
Move the OSS project's site from docs.onctl.io to onctl.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `onctl` is a tool to manage virtual machines in multi-cloud. 
 
-Check 🌍 https://docs.onctl.io for detailed documentation
+Check 🌍 https://onctl.sh for detailed documentation
 
 [![build](https://github.com/cdalar/onctl/actions/workflows/build.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/build.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cdalar/onctl/badge)](https://scorecard.dev/viewer/?uri=github.com/cdalar/onctl)
@@ -105,7 +105,7 @@ brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev
 ### Linux
 
 ```bash
-curl -sLS https://docs.onctl.io/get.sh | bash
+curl -sLS https://onctl.sh/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
@@ -114,7 +114,7 @@ sudo install onctl /usr/local/bin/
 To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
 
 ```bash
-curl -sLS https://docs.onctl.io/get_edge.sh | bash
+curl -sLS https://onctl.sh/get_edge.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 `onctl` is a tool to manage virtual machines in multi-cloud. 
 
-Check 🌍 https://docs.onctl.io for detailed documentation
+Check 🌍 https://onctl.sh for detailed documentation
 
 [![build](https://github.com/cdalar/onctl/actions/workflows/build.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/build.yml)
 [![Lint](https://github.com/cdalar/onctl/actions/workflows/lint.yml/badge.svg)](https://github.com/cdalar/onctl/actions/workflows/lint.yml)
@@ -41,7 +41,7 @@ brew install cdalar/tap/onctl
 ### Linux
 
 ```bash
-curl -sLS https://docs.onctl.io/get.sh | bash
+curl -sLS https://onctl.sh/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
@@ -50,7 +50,7 @@ sudo install onctl /usr/local/bin/
 To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
 
 ```bash
-curl -sLS https://docs.onctl.io/get_edge.sh | bash
+curl -sLS https://onctl.sh/get_edge.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://docs.onctl.io',
+  url: 'https://onctl.sh',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-docs.onctl.io
+onctl.sh


### PR DESCRIPTION
## Summary
- onctl.io is now the runner-business domain; the OSS onctl project needed its own, so it moved to the newly-purchased onctl.sh
- Serves at the domain root (no `docs.` subdomain) since the whole domain is now dedicated to this project
- Updates the GitHub Pages `CNAME`, Docusaurus's `url`, and every `docs.onctl.io` reference in `README.md`/`docs/docs/index.md` (the docs link + both `get.sh`/`get_edge.sh` install one-liners)

## Test plan
- [x] `npm run build` in `docs/` succeeds and `build/CNAME` contains `onctl.sh`
- [ ] Point onctl.sh's DNS at GitHub Pages and confirm the custom domain serves correctly once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUUwyWgX4uLP4grY6kxZWj