### PR TITLE
fix(edge): resolve OOM on onctl-4 runner, drop unused Windows target

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,7 +1,7 @@
 name: edge
 
 # Publishes an unsigned "edge" build of onctl from the tip of main on
-# every push -- a Linux/Windows binary carrying whatever just landed (e.g.
+# every push -- a Linux binary carrying whatever just landed (e.g.
 # #1074's per-VM guest hostname fix), for hosts like aimax to pick up
 # without waiting for a tagged, GPG-signed, Apple-notarized release
 # (goreleaser.yml's job, which this doesn't touch or replace). Named
@@ -17,8 +17,8 @@ name: edge
 # goreleaser-pro) + commented-out GORELEASER_KEY confirm this repo is on
 # the free tier. So this uses the OSS `--snapshot` flag instead (builds
 # unversioned artifacts, skips all publishing/validation) against a
-# dedicated .goreleaser.edge.yml (Linux/Windows only -- no macOS build,
-# no quill signing, no homebrew tap publish, none of which apply here),
+# dedicated .goreleaser.edge.yml (Linux only -- no macOS or Windows
+# build, no quill signing, no homebrew tap publish, none of which apply here),
 # then this workflow publishes the result itself: deletes and recreates a
 # single rolling `edge` prerelease/tag on every run, so there's always
 # exactly one, always-current release at a fixed URL

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -92,7 +92,13 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --snapshot --clean -f .goreleaser.edge.yml --skip=publish
+          # --parallelism=1: this workflow moved from ubuntu-latest (7-16GB)
+          # to the self-hosted onctl-4 runner, which can't sustain
+          # GoReleaser's default of building all 3 targets at once --
+          # compiling aws-sdk-go-v2/service/ec2 three times in parallel OOM
+          # (SIGKILL) on that box. Serializing the builds keeps peak memory
+          # to one target's worth at a time.
+          args: release --snapshot --clean -f .goreleaser.edge.yml --skip=publish --parallelism=1
 
       - name: Replace the rolling edge release
         env:

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           set -euo pipefail
           gh release delete edge --yes --cleanup-tag --repo cdalar/onctl 2>/dev/null || true
-          gh release create edge dist/*.tar.gz dist/*.zip dist/checksums.txt \
+          gh release create edge dist/*.tar.gz dist/checksums.txt \
             --repo cdalar/onctl \
             --target "${{ github.sha }}" \
             --title "edge ($(date -u +%Y-%m-%d))" \

--- a/.goreleaser.edge.yml
+++ b/.goreleaser.edge.yml
@@ -6,9 +6,13 @@ project_name: onctl
 # (real tagged releases: GPG-signed checksums, Apple-notarized macOS
 # binaries, homebrew tap publish). None of that applies to an edge build,
 # so it's a dedicated config rather than reusing goreleaser.yml with skip
-# flags -- no macOS build (no quill/notarization credentials needed, and
-# the hosts consuming edge builds today, e.g. aimax, are Linux anyway), no
-# signs section, no homebrew_casks.
+# flags -- Linux only (no macOS build: no quill/notarization credentials
+# needed, and the hosts consuming edge builds today, e.g. aimax, are Linux
+# anyway; no Windows build either -- nothing currently consumes it, and
+# every target GoReleaser builds runs in parallel on the self-hosted
+# onctl-4 runner this workflow builds on, so dropping it also helps keep
+# peak memory down alongside --parallelism=1 in edge.yml), no signs
+# section, no homebrew_casks.
 
 before:
   hooks:
@@ -21,13 +25,9 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
     goarch:
       - amd64
       - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
     ldflags:
       - -w -s -X 'github.com/cdalar/onctl/cmd.Version=v{{.Version}}-{{.ShortCommit}}'
 
@@ -35,9 +35,6 @@ archives:
   - id: repl
     name_template: "{{ .ProjectName }}-{{.Os}}-{{.Arch}}"
     formats: [tar.gz]
-    format_overrides:
-      - goos: windows
-        formats: [zip]
 
 checksum:
   name_template: checksums.txt

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ curl -sLS https://docs.onctl.io/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
-#### Edge build (latest `main`, Linux/Windows)
+#### Edge build (latest `main`, Linux only)
 
-To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
+To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS or Windows build):
 
 ```bash
 curl -sLS https://docs.onctl.io/get_edge.sh | bash

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,9 +45,9 @@ curl -sLS https://docs.onctl.io/get.sh | bash
 sudo install onctl /usr/local/bin/
 ```
 
-#### Edge build (latest `main`, Linux/Windows)
+#### Edge build (latest `main`, Linux only)
 
-To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS build):
+To install or update to the `edge` build, an unsigned binary rebuilt from the tip of `main` on every push (no macOS or Windows build):
 
 ```bash
 curl -sLS https://docs.onctl.io/get_edge.sh | bash

--- a/docs/static/get_edge.sh
+++ b/docs/static/get_edge.sh
@@ -3,7 +3,7 @@
 # Installs the "edge" build of onctl: an unsigned snapshot built from the
 # tip of main on every push (see .github/workflows/edge.yml), published as
 # a single rolling prerelease at a fixed tag rather than a versioned one.
-# Linux/Windows only -- the edge workflow does not build macOS binaries.
+# Linux only -- the edge workflow does not build macOS or Windows binaries.
 
 set -euo pipefail
 
@@ -35,13 +35,12 @@ case $os in
         extension=".tar.gz"
         unzip_command="tar zxvf"
         ;;
-    CYGWIN*|MINGW32*|MSYS*|MINGW*)
-        os="windows"
-        extension=".zip"
-        unzip_command="unzip -o"
-        ;;
     Darwin)
         echo "Error: no edge build is published for macOS -- use 'brew install --HEAD --fetch-HEAD cdalar/tap/onctl-dev' instead."
+        exit 1
+        ;;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        echo "Error: no edge build is published for Windows -- download a tagged release from the releases page instead."
         exit 1
         ;;
     *)
@@ -49,11 +48,6 @@ case $os in
         exit 1
         ;;
 esac
-
-if [ "$os" = "windows" ] && [ "$arch" = "arm64" ]; then
-    echo "Error: no edge build is published for windows/arm64."
-    exit 1
-fi
 
 echo "Installing onctl edge build ($os/$arch) from the '$TAG' release"
 
@@ -68,13 +62,7 @@ archive="onctl-${os}-${arch}-${TAG}${extension}"
 echo "Downloading onctl from $download_url"
 curl -fL "$download_url" -o "$archive"
 
-# Unzip the binary if on Windows or use tar command if on Linux
-if [ "$os" = "windows" ]; then
-    echo "Unzipping $archive"
-    $unzip_command "$archive" onctl.exe
-else
-    echo "Extracting $archive"
-    $unzip_command "$archive" onctl
-fi
+echo "Extracting $archive"
+$unzip_command "$archive" onctl
 
 echo "Download and unzip complete. onctl binary is in the current directory."


### PR DESCRIPTION
## Summary
- The `edge` workflow started failing after #e624e38 moved it from `ubuntu-latest` onto the self-hosted `onctl-4` runner: GoReleaser builds all targets in parallel by default, and compiling `aws-sdk-go-v2/service/ec2` three times at once (windows/amd64, linux/arm64, linux/amd64) OOM-killed the compiler on that box (confirmed live in run [34082530839](https://github.com/cdalar/onctl/actions/runs/34082530839): `signal: killed`).
- Adds `--parallelism=1` to the goreleaser invocation in `edge.yml`, serializing the target builds to cap peak memory to one target at a time.
- Also drops the Windows target entirely from `.goreleaser.edge.yml` (nothing currently consumes the edge Windows binary), a second independent way to reduce load on the constrained runner. Updates `get_edge.sh` and the README/docs "Edge build" sections to match (Linux only now), and drops the now-empty `dist/*.zip` glob from the release-publish step.

## Test plan
- [x] `goreleaser check -f .goreleaser.edge.yml` — config validates
- [x] `bash -n docs/static/get_edge.sh` — syntax check
- [x] Manually dispatched `edge.yml` on this branch 3 times to iterate live against the actual `onctl-4` runner (not guessable from a local machine): (1) `--parallelism=1` alone → [succeeded](https://github.com/cdalar/onctl/actions/runs/34084117686), confirming the root cause; (2) + dropped Windows → [build succeeded, release-publish failed](https://github.com/cdalar/onctl/actions/runs/34084368621) on the now-empty `dist/*.zip` glob; (3) + glob fix → [fully succeeded](https://github.com/cdalar/onctl/actions/runs/34084611048)
- [x] Confirmed the published `edge` release now has exactly `onctl-linux-amd64.tar.gz`, `onctl-linux-arm64.tar.gz`, `checksums.txt` (no Windows asset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx5i19SzjoDPrn1eccMzCe