### PR TITLE
Add Windows guest support to the ch (Cloud Hypervisor) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check 🌍 https://onctl.sh for detailed documentation
 - 🌍 Simple intuitive CLI to run VMs in seconds.  
 - ⛅️ Supports multi cloud providers (aws, azure, gcp, hetzner, more coming soon...)
 - 🔥 Run local microVMs with the `fc` (Firecracker) provider (Linux + KVM, no cloud account needed). No bare-metal Linux box? Create a nested-virtualization-enabled GCP VM (`gcp.vm.nestedVirtualization: true`) with `onctl create -n fc-host -a firecracker/firecracker-host-setup.sh`, then SSH in and run `ONCTL_CLOUD=fc onctl create -n my-microvm`.
-- 🐮 Run local microVMs with the `ch` ([Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)) provider — same idea as `fc` (Linux + KVM, no cloud account needed), no pause/resume support yet. Point `ch.kernelImage`/`ch.rootfsImage` at a kernel + rootfs image and run `ONCTL_CLOUD=ch onctl create -n my-microvm`.
+- 🐮 Run local microVMs with the `ch` ([Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)) provider — same idea as `fc` (Linux + KVM, no cloud account needed), no pause/resume support yet. Point `ch.kernelImage`/`ch.rootfsImage` at a kernel + rootfs image and run `ONCTL_CLOUD=ch onctl create -n my-microvm`. Also supports **Windows guests** via `--ch-os windows` (UEFI boot) — see [TESTING-ch-windows.md](TESTING-ch-windows.md) for base-image prep; unverified against real hardware.
 - 🚀 Sets your public key and Gives you SSH access with `onctl ssh <vm-name>`
 - ✨ Cloud-init support. Set your own cloud-init file `onctl up -n qwe --cloud-init <cloud.init.file>`
 - 🤖 Use ready to use templates to configure your vm. Check [onctl-templates](https://github.com/cdalar/onctl-templates) `onctl up -n qwe -a k3s/k3s-server.sh`

--- a/TESTING-ch-windows.md
+++ b/TESTING-ch-windows.md
@@ -1,0 +1,344 @@
+# Testing Windows guests on the `ch` provider
+
+**Status: VERIFIED — Windows Server 2025, full clean pipeline.** A real
+Windows Server 2025 Standard image was installed, syspreped, and
+successfully booted under real `cloud-hypervisor` (v53.0). A completely
+unmodified `onctl create` → `onctl ssh` → `onctl destroy` cycle (no manual
+console/registry intervention) was run end-to-end against it, through
+onctl's actual `ch.go`/`common.go` code path (`ConfigDriveSeedPreparer` +
+`DnsmasqDHCPManager`):
+```
+$ onctl create -n win2025-clean --provider ch --ch-os windows ... --username Administrator -k ~/.ssh/id_ed25519.pub
+✔ VM is Ready
+✔ VM Configured...
+$ onctl ssh win2025-clean -- "whoami & hostname"
+win2025-clean\administrator
+win2025-clean
+$ onctl destroy win2025-clean -f
+✔ VM Destroyed: win2025-clean
+```
+`--username` (or `ch.vm.username` in `onctl.yaml`) must be set to
+`Administrator` for both `create` and `ssh` — it's provider-level config,
+not stored per-VM, same as the rest of `ch`/`fc`.
+
+Windows 11 was **not** tested (TPM/Secure Boot bypass untested; expect the
+same fixes in §3d/§3e to apply, plus the LabConfig registry bypass Windows
+11's installer needs — see §3a).
+
+This mirrors `TESTING-fc.md`'s style: a manual runbook for a Linux/KVM host
+with `cloud-hypervisor` installed (same host `ch` already runs on for Linux
+guests).
+
+## 0. What you need before starting
+
+- A Linux/KVM host (bare metal or nested virt, same as `fc-host` /
+  `TESTING-fc.md`'s host).
+- `qemu-system-x86_64` + OVMF (`apt install qemu-system-x86 ovmf` on
+  Debian/Ubuntu) — used **only** to install/prep the Windows image; Cloud
+  Hypervisor itself has no installer.
+- A Windows Server or Windows 11 ISO. Cloud Hypervisor has only been tested
+  upstream (per its own docs) with Windows Server 2019, Windows Server Core
+  2004 and Windows 11 IoT Enterprise LTSC 2024 — **Windows 11 with TPM 2.0
+  enabled is documented as not working**; disable/skip TPM. Windows Server
+  2025 (this doc's actually-verified target) works too.
+- The [virtio-win driver ISO](https://github.com/virtio-win/virtio-win-pkg-scripts)
+  (paravirtual storage/net drivers Windows needs to see the guest's disks
+  and NIC at all). **Only install the modern per-OS-folder drivers** (e.g.
+  `NetKVM\2k25\amd64\`, `viostor\2k25\amd64\`) — a blind
+  `pnputil /add-driver *.inf /subdirs` also picks up old, self-signed
+  test-cert drivers from ancient OS folders (`Balloon\2k12\...`) that
+  trigger an interactive "Windows Security" driver-signing prompt with no
+  way to dismiss it headlessly (it renders on an input-isolated
+  desktop/session synthetic keystrokes can't reach). Scope every
+  `pnputil` call to the specific `<driver>\<osfolder>\amd64\` directory
+  instead.
+- [cloudbase-init](https://cloudbase-init.readthedocs.io/) — the Windows
+  cloud-image customization agent onctl's seed ISO targets (§3). Install it
+  inside the guest during image prep, same idea as `cloud-init` on a Linux
+  cloud image. Silent install: `msiexec /i CloudbaseInitSetup_Stable_x64.msi
+  /qn /norestart RUNSERVICEASLOCALSYSTEM=1 LOGGINGSERIALPORTNAME=COM1`. The
+  installer automatically registers a sysprep hook
+  (`<install dir>\conf\Unattend.xml`) — run sysprep with
+  `/unattend:"<that path>"` (§3c) rather than a bare `/generalize /oobe
+  /shutdown`, so cloudbase-init actually re-runs after generalization.
+- `genisoimage`, `mkisofs`, or `xorriso` on the **onctl host** (not the
+  guest) — onctl shells out to whichever is found first to build the seed
+  ISO (`internal/providerch/common.go`'s `isoBuilders`).
+- `dnsmasq` on the onctl host — used for DHCP on the Windows path only (the
+  Linux `ch` path is untouched and doesn't need it).
+
+## 1. Get Cloud Hypervisor's UEFI firmware
+
+```bash
+curl -LO https://github.com/cloud-hypervisor/edk2/releases/latest/download/CLOUDHV.fd
+mkdir -p ~/.onctl/cloud-hypervisor/images
+mv CLOUDHV.fd ~/.onctl/cloud-hypervisor/images/
+```
+
+## 2. Create the raw disk image
+
+```bash
+qemu-img create -f raw ~/.onctl/cloud-hypervisor/images/windows.raw 40G   # 40G is enough for Server; use 64G for Windows 11
+```
+
+## 3. Install Windows under QEMU+OVMF, with virtio-win + cloudbase-init
+
+An unattended `autounattend.xml` install works well here (see Microsoft's
+own answer-file schema) and is what was actually used to produce the
+verified image — a manual VNC-driven install works identically. Either way,
+install onto a **plain SATA/AHCI disk** (`-drive ...,if=none,id=disk0
+-device ahci,id=ahci0 -device ide-hd,bus=ahci0.0,drive=disk0`), not
+virtio-blk — this sidesteps needing a WinPE-phase driver injection just to
+get Setup to see the disk at all. Attach the Windows ISO, and separately
+attach virtio-win.iso for driver injection **after** install (§3b).
+
+```bash
+qemu-system-x86_64 \
+  -enable-kvm -machine q35 -cpu host -smp 2 -m 4096 \
+  -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd \
+  -drive if=pflash,format=raw,file=/tmp/OVMF_VARS.fd \
+  -device ahci,id=ahci0 \
+  -drive if=none,id=disk0,format=raw,file=~/.onctl/cloud-hypervisor/images/windows.raw \
+  -device ide-hd,bus=ahci0.0,drive=disk0 \
+  -drive if=none,id=cd0,media=cdrom,file=windows-server-2025.iso \
+  -device ide-cd,bus=ahci0.1,drive=cd0 \
+  -netdev user,id=net0 -device e1000,netdev=net0 \
+  -boot order=d,menu=off \
+  -vnc :0
+```
+
+(Watch for the "Press any key to boot from CD" El Torito prompt in the
+first couple of boot seconds — miss it and Setup falls through to PXE.)
+
+After install completes and you're at a logged-in desktop:
+
+### 3a. (Windows 11 only) TPM/Secure Boot bypass
+
+Not needed for Windows Server. For Windows 11, add a `RunSynchronous` block
+to the `windowsPE` pass of `autounattend.xml` running, before disk setup:
+```
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassTPMCheck /t REG_DWORD /d 1 /f
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassSecureBootCheck /t REG_DWORD /d 1 /f
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassRAMCheck /t REG_DWORD /d 1 /f
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassStorageCheck /t REG_DWORD /d 1 /f
+reg add HKLM\SYSTEM\Setup\LabConfig /v BypassCPUCheck /t REG_DWORD /d 1 /f
+```
+This part is **unverified** — derived from well-documented community
+practice, not confirmed against a real install in this pass.
+
+### 3b. Install virtio-win drivers, scoped to the target OS folder only
+
+```powershell
+$osFolder = "2k25"   # or "w11" for Windows 11
+Get-ChildItem E:\ -Recurse -Filter *.inf |
+  Where-Object { $_.FullName -match "\\$osFolder\\amd64\\" } |
+  ForEach-Object { pnputil /add-driver $_.FullName /install }
+```
+(`E:` = the mounted virtio-win ISO.) This only stages the drivers into the
+**driver store** — it does *not* make the boot disk bootable from
+virtio-blk by itself. See §3d.
+
+### 3c. Install cloudbase-init and sysprep
+
+```powershell
+msiexec /i CloudbaseInitSetup_Stable_x64.msi /qn /norestart RUNSERVICEASLOCALSYSTEM=1 LOGGINGSERIALPORTNAME=COM1
+
+$conf = "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf"
+Add-Content "$conf\cloudbase-init.conf" "metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService"
+Add-Content "$conf\cloudbase-init-unattend.conf" "metadata_services=cloudbaseinit.metadata.services.configdrive.ConfigDriveService"
+
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Start-Service sshd
+Set-Service sshd -StartupType Automatic
+
+& "$env:WINDIR\System32\Sysprep\sysprep.exe" /generalize /oobe /shutdown /unattend:"$conf\Unattend.xml"
+```
+
+Shut down after sysprep completes. `windows.raw` is now the reusable base
+image — onctl copies it per-VM (`ch.rootfsImage`, or `--ch-rootfs-image`)
+and never modifies it in place, same contract as the Linux `rootfs.ext4`
+base image.
+
+### 3d. Make the boot disk actually bootable from virtio-blk
+
+**This is the step that isn't obvious and will boot-loop
+(`INACCESSIBLE_BOOT_DEVICE`, no on-screen error since Cloud Hypervisor has
+no VGA) if skipped.** `pnputil /add-driver` alone does not register
+`viostor` as a **boot-critical** driver — that requires a
+`CriticalDeviceDatabase` entry mapping the virtio-blk PCI hardware ID to
+the service, and that entry only gets created automatically by live PnP
+enumeration of an actually-present device — which never happened, since
+Setup ran against a SATA disk (§3, deliberately, to dodge WinPE driver
+injection).
+
+Confirmed via `viostor.inf` under `virtio-win.iso` (device IDs are
+spec-standard across VMMs; Cloud Hypervisor's own subsystem ID differs from
+QEMU's, so add both the QEMU- and CH-shaped IDs, plus the ID-only fallback):
+
+```bash
+# offline, from the host — mount the image and add the CDD keys directly
+losetup -fP --show windows.raw            # e.g. /dev/loop0
+mount -t ntfs3 /dev/loop0p3 /mnt/win        # ntfs3 kernel driver (Linux 5.15+)
+```
+
+```
+reged -I /mnt/win/Windows/System32/config/SYSTEM "HKEY_LOCAL_MACHINE\SYSTEM" cdd_fix.reg
+```
+where `cdd_fix.reg` contains, for **both** `ControlSet001` and
+`ControlSet002` (check `HKLM\SYSTEM\Select` for which is current):
+```
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\CriticalDeviceDatabase\pci#ven_1af4&dev_1042]
+"ClassGUID"="{4D36E97B-E325-11CE-BFC1-08002BE10318}"
+"Service"="viostor"
+
+[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Control\CriticalDeviceDatabase\pci#ven_1af4&dev_1042&subsys_10421af4&rev_01]
+"ClassGUID"="{4D36E97B-E325-11CE-BFC1-08002BE10318}"
+"Service"="viostor"
+```
+(`10421af4` is Cloud Hypervisor's subsystem ID for virtio-blk — its
+`PciConfiguration::new(...)` sets `subsystem_vendor_id`/`subsystem_device_id`
+to the same values as the main vendor/device ID, i.e.
+`VIRTIO_PCI_VENDOR_ID` (0x1af4) and `0x1040 + block(2) = 0x1042` — a
+*different* convention from QEMU's `1100`-based subsystem IDs. The
+ID-only key without `&subsys_...&rev_...` is what actually made this work
+in practice; keep it regardless of which VMM you're targeting.)
+
+Alternative that reaches the same end state with no offline registry
+surgery: after §3c but **before** the final sysprep+shutdown, boot the
+image once under QEMU with `-drive ...,if=virtio` instead of AHCI/SATA —
+a live PnP pass against a real virtio-blk device writes the same
+boot-critical registration automatically. This is what was actually done
+to produce the verified image, and it's also how the two gotchas below
+were caught.
+
+### 3e. Two more gotchas that only show up once the disk boots
+
+Both are guest-OS/network-stack issues, not onctl-specific — but they will
+silently prevent `onctl ssh` from working even once boot succeeds, so fix
+them in the base image now:
+
+1. **`administrators_authorized_keys`.** Windows' OpenSSH Server has a
+   `Match Group administrators` rule in `sshd_config` that ignores
+   `~/.ssh/authorized_keys` for admin-group accounts (which `Administrator`
+   always is) in favor of `%ProgramData%\ssh\administrators_authorized_keys`.
+   cloudbase-init's `SetUserSSHPublicKeysPlugin` writes only the per-user
+   file, so admin login still fails after a clean cloudbase-init run.
+   **Do not just comment out the `Match Group administrators` block** —
+   that block exists because Windows OpenSSH's normal per-user
+   `%h`-relative `authorized_keys` resolution is unreliable for the
+   built-in Administrator account specifically (its profile directory is
+   `C:\Users\Admin`, not `C:\Users\Administrator`); removing the block was
+   tried here and made login fail outright, not just fall back to a
+   different file. Keep the block, and instead add a cloudbase-init
+   `LocalScriptsPlugin` script (drop a `.ps1` in
+   `C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\` —
+   already on `local_scripts_path` in `cloudbase-init.conf` by default,
+   runs last, after `SetUserSSHPublicKeysPlugin`) that copies whichever
+   per-user `authorized_keys` was just written to
+   `%ProgramData%\ssh\administrators_authorized_keys`:
+   ```powershell
+   $src = Get-ChildItem "C:\Users\*\.ssh\authorized_keys" -ErrorAction SilentlyContinue |
+       Sort-Object LastWriteTime -Descending | Select-Object -First 1
+   if ($src) {
+       $dest = "C:\ProgramData\ssh\administrators_authorized_keys"
+       Copy-Item $src.FullName $dest -Force
+       icacls $dest /inheritance:r /grant Administrators:F /grant SYSTEM:F | Out-Null
+   }
+   ```
+   (`icacls` is required — sshd rejects that file if it's readable by
+   anyone else.) This re-runs on every fresh onctl deployment (new
+   instance UUID → cloudbase-init treats it as unseen → all plugins,
+   including this script, run again), so it isn't a one-off fix tied to a
+   single VM's key.
+2. **Network profile defaults to Public after generalize**, and the
+   OpenSSH-capability's auto-created firewall rule
+   (`OpenSSH SSH Server (sshd)`) is scoped to the **Private** profile only
+   — so even with the key fixed, the SSH port is unreachable. Fix in the
+   base image: `Set-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -Profile
+   Any` (broadening the rule is more robust than trying to force the
+   network category, which sysprep resets on every generalize).
+
+## 4. Sanity-check the image boots under Cloud Hypervisor directly (bypassing onctl)
+
+Do this **before** wiring onctl in at all — it isolates "does Cloud
+Hypervisor + this image work" from "does onctl's seed-ISO/DHCP code work".
+No VGA means no on-screen errors; if this hangs or resets in a loop with
+nothing useful in the log, enable EMS first (`bcdedit /ems on;
+bcdedit /emssettings EMSPORT:1 EMSBAUDRATE:115200` inside the guest, one
+more boot under QEMU, then shut down) so boot diagnostics and the SAC
+console mirror to COM1/the `--serial tty` log.
+
+```bash
+cp ~/.onctl/cloud-hypervisor/images/windows.raw /tmp/win-test.raw
+
+sudo cloud-hypervisor \
+  --api-socket /tmp/ch.sock \
+  --kernel ~/.onctl/cloud-hypervisor/images/CLOUDHV.fd \
+  --disk path=/tmp/win-test.raw \
+  --cpus boot=2,kvm_hyperv=on \
+  --memory size=4096M \
+  --net "tap=,mac=52:54:00:12:34:56" \
+  --serial tty --console off
+```
+
+If this doesn't boot to a login/SAC prompt, nothing above it (onctl's DHCP
+or seed-ISO plumbing) will work either — fix the image/firmware first (most
+likely §3d).
+
+## 5. Run onctl end-to-end
+
+```bash
+sudo onctl create -n win-test --provider ch --ch-os windows \
+  --ch-kernel-image ~/.onctl/cloud-hypervisor/images/CLOUDHV.fd \
+  --ch-rootfs-image ~/.onctl/cloud-hypervisor/images/windows.raw \
+  --vcpu 2 --memory 4096 \
+  --username Administrator \
+  -k ~/.ssh/id_rsa.pub
+
+# `ssh` has no --username flag (unlike `create`) -- set it once in
+# onctl.yaml instead (ch.vm.username: Administrator), or it defaults to
+# root and auth fails.
+sudo onctl ssh win-test -- whoami   # confirm cloudbase-init applied the hostname/SSH key and sshd is reachable
+
+sudo onctl destroy win-test -f   # confirm the bridge/tap/DHCP reservation/state dir are all cleaned up
+```
+
+## 6. Confirm the Linux `ch` path is unaffected
+
+```bash
+sudo onctl create -n linux-test --provider ch \
+  --ch-kernel-image ~/.onctl/cloud-hypervisor/images/vmlinux \
+  --ch-rootfs-image ~/.onctl/cloud-hypervisor/images/rootfs.ext4
+sudo onctl ssh linux-test
+sudo onctl destroy linux-test -f
+```
+
+(no `--ch-os` needed — defaults to `linux`, unchanged from before this
+integration.)
+
+## Known limitations
+
+- No VGA console — interact via SSH (once cloudbase-init + sshd are up) or
+  Cloud Hypervisor's serial-port SAC (`--serial tty`; enable EMS in the
+  guest first, §4).
+- No pause/resume/snapshot for `ch` at all (Windows or Linux) — `onctl
+  destroy` + `onctl create` only.
+- Windows 11 + TPM 2.0 is documented upstream as not working on Cloud
+  Hypervisor. Windows 11 generally (TPM bypassed) has not been tested here
+  — only Windows Server 2025.
+- Two real dnsmasq bugs were found and fixed while verifying this:
+  `chMAC()` used to emit a mixed-case address (`02:C4:...`); dnsmasq's
+  `--dhcp-hostsfile` matching is case-sensitive against the
+  lowercase-normalized MAC a DHCP client actually sends, so the
+  reservation silently never matched its own guest. And
+  `DnsmasqDHCPManager` used to rely on dnsmasq's system-wide default lease
+  file (`/var/lib/misc/dnsmasq.leases`), shared with *any* other dnsmasq on
+  the host — a stale lease there for an onctl-reserved address (e.g. from
+  an unrelated manual test) silently wins over a fresh
+  `--dhcp-hostsfile` reservation for the same address, no error, dnsmasq
+  just allocates a different one from the free pool. Both are fixed
+  (`chMAC` is lowercase throughout; each bridge gets its own
+  `--dhcp-leasefile` under onctl's state dir) — if you're testing against
+  an onctl build from before this fix, watch for `onctl ssh` timing out to
+  the IP `onctl ls` reports, and check `ip neigh` / dnsmasq's own DHCPOFFER
+  log for a mismatch.

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -54,6 +54,7 @@ var (
 	flagCHKernelImage string
 	flagCHRootfsImage string
 	flagCHBinary      string
+	flagCHOS          string
 	// GCP-specific flag bound to gcp.project (see init below). This replaces
 	// the placeholder in onctl.yaml's gcp.project (the one GCP setting with
 	// no static default; it's account-specific).
@@ -159,12 +160,14 @@ func init() {
 	// shared with fc's flags of the same purpose above: their defaults point
 	// at different image directories, and a shared flag can only carry one
 	// default value.
-	createCmd.Flags().StringVar(&flagCHKernelImage, "ch-kernel-image", "~/.onctl/cloud-hypervisor/images/vmlinux", "Cloud Hypervisor: path to the uncompressed kernel (vmlinux)")
-	createCmd.Flags().StringVar(&flagCHRootfsImage, "ch-rootfs-image", "~/.onctl/cloud-hypervisor/images/rootfs.ext4", "Cloud Hypervisor: path to the base rootfs (ext4)")
+	createCmd.Flags().StringVar(&flagCHKernelImage, "ch-kernel-image", "~/.onctl/cloud-hypervisor/images/vmlinux", "Cloud Hypervisor: path to the uncompressed kernel (vmlinux) for --ch-os linux, or the UEFI firmware (CLOUDHV.fd) for --ch-os windows")
+	createCmd.Flags().StringVar(&flagCHRootfsImage, "ch-rootfs-image", "~/.onctl/cloud-hypervisor/images/rootfs.ext4", "Cloud Hypervisor: path to the base rootfs (ext4) for --ch-os linux, or a UEFI-bootable Windows disk image for --ch-os windows")
 	createCmd.Flags().StringVar(&flagCHBinary, "ch-binary", "cloud-hypervisor", "Cloud Hypervisor: path to the cloud-hypervisor binary")
+	createCmd.Flags().StringVar(&flagCHOS, "ch-os", "linux", "Cloud Hypervisor: guest OS boot path, \"linux\" (direct kernel boot) or \"windows\" (UEFI firmware boot; requires a pre-built image with virtio drivers and cloudbase-init — see docs). UNVERIFIED: the windows path has not been run against real hardware yet")
 	_ = viper.BindPFlag("ch.kernelImage", createCmd.Flags().Lookup("ch-kernel-image"))
 	_ = viper.BindPFlag("ch.rootfsImage", createCmd.Flags().Lookup("ch-rootfs-image"))
 	_ = viper.BindPFlag("ch.binPath", createCmd.Flags().Lookup("ch-binary"))
+	_ = viper.BindPFlag("ch.os", createCmd.Flags().Lookup("ch-os"))
 	_ = viper.BindPFlag("ch.vcpuCount", createCmd.Flags().Lookup("vcpu"))
 	_ = viper.BindPFlag("ch.memSizeMib", createCmd.Flags().Lookup("memory"))
 	_ = viper.BindPFlag("ch.vm.username", createCmd.Flags().Lookup("username"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -236,10 +236,12 @@ func initProvider(cloudProvider string) {
 	case "ch":
 		chConfig := providerch.GetConfig()
 		provider = &cloud.ProviderCH{
-			Config:  chConfig,
-			Process: providerch.NewProcessManager(chConfig.BinPath),
-			Net:     providerch.NewNetworkManager(),
-			Rootfs:  providerch.NewRootfsPreparer(),
+			Config:       chConfig,
+			Process:      providerch.NewProcessManager(chConfig.BinPath),
+			Net:          providerch.NewNetworkManager(),
+			Rootfs:       providerch.NewRootfsPreparer(),
+			WindowsGuest: providerch.NewWindowsGuestPreparer(),
+			DHCP:         providerch.NewDHCPManager(chConfig.StateDir),
 		}
 	case "static":
 		path, err := onctlSSHConfigPath()

--- a/internal/files/init/onctl.yaml
+++ b/internal/files/init/onctl.yaml
@@ -88,9 +88,10 @@ fc:
 # Same idea as fc above (local VMM microVMs, no cloud account), but no
 # pause/resume/snapshot support yet.
 ch:
-  kernelImage: ~/.onctl/cloud-hypervisor/images/vmlinux  # uncompressed kernel (vmlinux)
-  rootfsImage: ~/.onctl/cloud-hypervisor/images/rootfs.ext4 # base rootfs, copied per-VM
-  # kernelArgs: "console=ttyS0 reboot=k panic=1 root=/dev/vda rw net.ifnames=0 biosdevname=0"
+  os: linux                        # "linux" (default) or "windows" (UEFI boot; see docs/windows-ch.md — unverified against real hardware)
+  kernelImage: ~/.onctl/cloud-hypervisor/images/vmlinux  # uncompressed kernel (vmlinux) for os=linux, or UEFI firmware (CLOUDHV.fd) for os=windows
+  rootfsImage: ~/.onctl/cloud-hypervisor/images/rootfs.ext4 # base rootfs (ext4) for os=linux, copied per-VM; or a UEFI-bootable Windows disk image for os=windows
+  # kernelArgs: "console=ttyS0 reboot=k panic=1 root=/dev/vda rw net.ifnames=0 biosdevname=0"  # os=linux only
   vcpuCount: 1
   memSizeMib: 2048
   binPath: cloud-hypervisor        # path to the cloud-hypervisor binary
@@ -98,5 +99,5 @@ ch:
     bridge: chbr0                  # host bridge microVM TAP devices attach to
     cidr: 172.17.0.1/24            # bridge address/subnet; address is the microVM gateway
   vm:
-    username: root                 # ssh user configured in the rootfs image
+    username: root                 # ssh user configured in the rootfs image (os=linux) or the local admin account (os=windows)
   # stateDir: /opt/ch              # default: /opt/ch

--- a/internal/providerch/common.go
+++ b/internal/providerch/common.go
@@ -6,6 +6,7 @@ package providerch
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -94,6 +96,11 @@ func GetConfig() cloud.CHConfig {
 		binPath = "cloud-hypervisor"
 	}
 
+	guestOS := strings.ToLower(strings.TrimSpace(viper.GetString("ch.os")))
+	if guestOS == "" {
+		guestOS = "linux"
+	}
+
 	return cloud.CHConfig{
 		KernelImage: expandHome(viper.GetString("ch.kernelImage")),
 		RootfsImage: expandHome(viper.GetString("ch.rootfsImage")),
@@ -105,6 +112,7 @@ func GetConfig() cloud.CHConfig {
 		Username:    username,
 		BinPath:     binPath,
 		StateDir:    stateDir,
+		OS:          guestOS,
 	}
 }
 
@@ -172,6 +180,10 @@ type chVMConfigPayload struct {
 type chCPUsConfig struct {
 	BootVCPUs int64 `json:"boot_vcpus"`
 	MaxVCPUs  int64 `json:"max_vcpus"`
+	// KvmHyperv enables Hyper-V enlightenments, required for Windows
+	// guests (confirmed against cloud-hypervisor's CpusConfig OpenAPI
+	// schema; omitted entirely for Linux guests via omitempty).
+	KvmHyperv bool `json:"kvm_hyperv,omitempty"`
 }
 
 type chMemoryConfig struct {
@@ -181,14 +193,21 @@ type chMemoryConfig struct {
 
 // chPayloadConfig is Cloud Hypervisor's PayloadConfig: unlike Firecracker,
 // the kernel path and boot command line are plain string fields nested
-// under "payload", not top-level "kernel"/"cmdline" objects.
+// under "payload", not top-level "kernel"/"cmdline" objects. Firmware is
+// the UEFI boot path (mutually exclusive with Kernel/Cmdline, confirmed
+// against PayloadConfig's OpenAPI schema) used for Windows guests, which
+// have no direct-kernel-boot path.
 type chPayloadConfig struct {
-	Kernel  string `json:"kernel"`
-	Cmdline string `json:"cmdline,omitempty"`
+	Firmware string `json:"firmware,omitempty"`
+	Kernel   string `json:"kernel,omitempty"`
+	Cmdline  string `json:"cmdline,omitempty"`
 }
 
 type chDiskConfig struct {
 	Path string `json:"path"`
+	// Readonly marks a disk as read-only — used for the Windows NoCloud
+	// seed ISO, which must never be written to.
+	Readonly bool `json:"readonly,omitempty"`
 }
 
 type chNetConfig struct {
@@ -207,11 +226,21 @@ type chConsoleConfig struct {
 func configureAndBoot(socketPath string, cfg cloud.CHVMConfig) error {
 	client := unixHTTPClient(socketPath)
 
+	payloadCfg := chPayloadConfig{Kernel: cfg.KernelImage, Cmdline: cfg.KernelArgs}
+	if cfg.Firmware {
+		payloadCfg = chPayloadConfig{Firmware: cfg.KernelImage}
+	}
+
+	disks := []chDiskConfig{{Path: cfg.RootfsPath}}
+	if cfg.SeedDiskPath != "" {
+		disks = append(disks, chDiskConfig{Path: cfg.SeedDiskPath, Readonly: true})
+	}
+
 	payload := chVMConfigPayload{
-		CPUs:    chCPUsConfig{BootVCPUs: cfg.VCPUCount, MaxVCPUs: cfg.VCPUCount},
+		CPUs:    chCPUsConfig{BootVCPUs: cfg.VCPUCount, MaxVCPUs: cfg.VCPUCount, KvmHyperv: cfg.KvmHyperv},
 		Memory:  chMemoryConfig{Size: cfg.MemSizeMib * 1024 * 1024},
-		Payload: chPayloadConfig{Kernel: cfg.KernelImage, Cmdline: cfg.KernelArgs},
-		Disks:   []chDiskConfig{{Path: cfg.RootfsPath}},
+		Payload: payloadCfg,
+		Disks:   disks,
 		Net:     []chNetConfig{{Tap: cfg.TapDevice, Mac: cfg.MacAddress}},
 		// Tty: guest serial console output is written to the VMM process's
 		// own stdout, which spawn() redirects to logFile, mirroring how
@@ -555,4 +584,357 @@ func runDebugfsScript(rootfsPath, script string) error {
 		return fmt.Errorf("debugfs failed: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// ConfigDriveSeedPreparer is the real cloud.WindowsGuestPreparer
+// implementation: it copies the base Windows disk image unmodified (Windows
+// disks are NTFS, which onctl has no in-process tooling to modify — unlike
+// DebugfsRootfsPreparer's ext4 debugfs trick, so it never touches the guest
+// disk at all) and builds an OpenStack config-drive-format seed ISO for
+// cloudbase-init (which must be pre-installed in the base image, alongside
+// virtio-win drivers — see docs) to apply hostname/SSH-key configuration
+// from at boot.
+//
+// UNVERIFIED: this has not been exercised against a real cloudbase-init
+// installation. The config-drive layout and meta_data.json fields below
+// (openstack/latest/meta_data.json + public_keys) match OpenStack's and
+// cloudbase-init's own documented ConfigDrive datasource, but should be
+// confirmed by hand-booting one seed ISO against the actual cloudbase-init
+// version in use before relying on this (see the plan's Verification § 0).
+type ConfigDriveSeedPreparer struct{}
+
+// NewWindowsGuestPreparer returns a cloud.WindowsGuestPreparer backed by
+// ConfigDriveSeedPreparer.
+func NewWindowsGuestPreparer() cloud.WindowsGuestPreparer {
+	return ConfigDriveSeedPreparer{}
+}
+
+func (ConfigDriveSeedPreparer) PrepareDisk(baseImage, destPath string) error {
+	if baseImage == "" {
+		return errors.New("ch.rootfsImage is not configured")
+	}
+	return copyRootfs(baseImage, destPath)
+}
+
+// configDriveMetadata mirrors OpenStack's meta_data.json (the subset
+// cloudbase-init's ConfigDrive datasource reads).
+type configDriveMetadata struct {
+	UUID        string            `json:"uuid"`
+	Hostname    string            `json:"hostname"`
+	Name        string            `json:"name"`
+	PublicKeys  map[string]string `json:"public_keys,omitempty"`
+	LaunchIndex int               `json:"launch_index"`
+}
+
+func (ConfigDriveSeedPreparer) BuildSeedISO(destPath, hostname, sshPublicKey, username string) error {
+	seedDir, err := os.MkdirTemp("", "onctl-ch-seed-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(seedDir) }()
+
+	osDir := filepath.Join(seedDir, "openstack", "latest")
+	if err := os.MkdirAll(osDir, 0755); err != nil {
+		return err
+	}
+
+	meta := configDriveMetadata{
+		UUID:     configDriveUUID(hostname),
+		Hostname: hostname,
+		Name:     hostname,
+	}
+	if sshPublicKey != "" {
+		if username == "" {
+			username = "root"
+		}
+		meta.PublicKeys = map[string]string{username: sshPublicKey}
+	}
+	metaJSON, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(osDir, "meta_data.json"), metaJSON, 0644); err != nil {
+		return err
+	}
+	// user_data is optional per the config-drive spec; an empty file is
+	// enough for cloudbase-init to skip it rather than error out.
+	if err := os.WriteFile(filepath.Join(osDir, "user_data"), []byte{}, 0644); err != nil {
+		return err
+	}
+
+	return buildISO(seedDir, destPath, "config-2")
+}
+
+// configDriveUUID derives a deterministic, UUID-shaped instance id from
+// hostname. It only needs to be a stable, plausible-looking identifier —
+// cloudbase-init doesn't validate it against anything — so a random UUID
+// isn't necessary.
+func configDriveUUID(hostname string) string {
+	sum := md5.Sum([]byte(hostname))
+	return fmt.Sprintf("%x-%x-%x-%x-%x", sum[0:4], sum[4:6], sum[6:8], sum[8:10], sum[10:16])
+}
+
+// isoBuilders are candidate ISO9660-building tools, tried in order; the
+// first one found on PATH is used. All three accept the same genisoimage
+// -style flags (xorriso via its "-as genisoimage" emulation mode).
+var isoBuilders = []string{"genisoimage", "mkisofs", "xorriso"}
+
+// buildISO packages sourceDir as an ISO9660+Joliet+RockRidge volume at
+// destPath, labeled volLabel.
+func buildISO(sourceDir, destPath, volLabel string) error {
+	for _, bin := range isoBuilders {
+		if _, err := exec.LookPath(bin); err != nil {
+			continue
+		}
+		args := []string{"-o", destPath, "-V", volLabel, "-J", "-R", sourceDir}
+		if bin == "xorriso" {
+			args = append([]string{"-as", "genisoimage"}, args...)
+		}
+		out, err := exec.Command(bin, args...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s failed: %w: %s", bin, err, strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	return errors.New("no ISO-building tool found on PATH (tried genisoimage, mkisofs, xorriso) — install one to use ch.os=windows")
+}
+
+// DnsmasqDHCPManager is the real cloud.DHCPManager implementation: it runs
+// one dnsmasq instance per bridge, serving DHCP only (--port=0 disables its
+// built-in DNS server, since onctl has no use for it and it would otherwise
+// compete with the host's own resolver on port 53).
+//
+// UNVERIFIED: like ConfigDriveSeedPreparer, this has not been run against a
+// real dnsmasq/cloud-hypervisor/Windows-guest chain.
+type DnsmasqDHCPManager struct {
+	// StateDir is where per-bridge dnsmasq PID/lease/hosts files live
+	// (Config.StateDir from CHConfig).
+	StateDir string
+}
+
+// NewDHCPManager returns a cloud.DHCPManager backed by dnsmasq, storing its
+// per-bridge state files under stateDir.
+func NewDHCPManager(stateDir string) cloud.DHCPManager {
+	return DnsmasqDHCPManager{StateDir: stateDir}
+}
+
+func (m DnsmasqDHCPManager) dhcpDir(bridge string) string {
+	return filepath.Join(m.StateDir, "dhcp", bridge)
+}
+
+func (m DnsmasqDHCPManager) pidFile(bridge string) string {
+	return filepath.Join(m.dhcpDir(bridge), "dnsmasq.pid")
+}
+
+func (m DnsmasqDHCPManager) hostsFile(bridge string) string {
+	return filepath.Join(m.dhcpDir(bridge), "hosts")
+}
+
+func (m DnsmasqDHCPManager) leaseFile(bridge string) string {
+	return filepath.Join(m.dhcpDir(bridge), "leases")
+}
+
+// EnsureDHCP starts a dnsmasq instance bound to bridge if one isn't already
+// running, serving the whole of cidr's host range minus the gateway
+// address. Idempotent, like NetworkManager.EnsureBridge.
+func (m DnsmasqDHCPManager) EnsureDHCP(bridge, cidr string) error {
+	if m.isRunning(bridge) {
+		return nil
+	}
+	dir := m.dhcpDir(bridge)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	hostsFile := m.hostsFile(bridge)
+	if _, err := os.Stat(hostsFile); os.IsNotExist(err) {
+		if err := os.WriteFile(hostsFile, []byte{}, 0644); err != nil {
+			return err
+		}
+	}
+	rangeStart, rangeEnd, err := dhcpRange(cidr)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("dnsmasq",
+		"--port=0", // DHCP only; no DNS service.
+		"--interface="+bridge,
+		"--bind-interfaces",
+		"--dhcp-range="+rangeStart+","+rangeEnd+",12h",
+		"--dhcp-hostsfile="+hostsFile,
+		// Scoped under our own state dir rather than dnsmasq's system-wide
+		// default (/var/lib/misc/dnsmasq.leases): that default is shared
+		// with any other dnsmasq usage on the host (another bridge, a
+		// manual test, libvirt, ...), and a stale lease there for an
+		// address a --dhcp-hostsfile reservation now claims silently wins
+		// — dnsmasq won't hand out an address it still has recorded as
+		// leased to a different MAC, no error, it just allocates from the
+		// free pool instead. A private lease file per bridge avoids ever
+		// colliding with unrelated leases.
+		"--dhcp-leasefile="+m.leaseFile(bridge),
+		"--pid-file="+m.pidFile(bridge),
+		"--except-interface=lo",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start dnsmasq for %q: %w: %s", bridge, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+func (m DnsmasqDHCPManager) isRunning(bridge string) bool {
+	data, err := os.ReadFile(m.pidFile(bridge))
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}
+
+// AddReservation appends a "mac,ip" line to the bridge's dnsmasq
+// --dhcp-hostsfile and asks dnsmasq to reread it. It relies on the caller
+// (ProviderCH.Deploy) having called EnsureDHCP first for the same bridge —
+// there is no bridge parameter here because CHVMConfig/DHCPManager's
+// Deploy-time call sites don't thread it through per-reservation; if that
+// turns out to be needed in practice (e.g. multiple ch.network.bridge
+// values in use), this will need a bridge parameter added.
+//
+// mac is lowercased before writing: dnsmasq's --dhcp-hostsfile matching is
+// case-sensitive against the lowercase-normalized MAC a DHCP client
+// actually sends, so any mixed-case address here would silently never
+// match its own reservation (caught via chMAC, which used to emit
+// "02:C4:..." — see its doc comment).
+func (m DnsmasqDHCPManager) AddReservation(mac, ip string) error {
+	mac = strings.ToLower(mac)
+	return m.withEachBridgeHostsFile(func(bridge, hostsFile string) error {
+		f, err := os.OpenFile(hostsFile, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		if _, err := fmt.Fprintf(f, "%s,%s\n", mac, ip); err != nil {
+			return err
+		}
+		return m.reload(bridge)
+	})
+}
+
+// RemoveReservation removes a "mac,..." line previously added by
+// AddReservation and asks dnsmasq to reread the file.
+func (m DnsmasqDHCPManager) RemoveReservation(mac string) error {
+	mac = strings.ToLower(mac)
+	return m.withEachBridgeHostsFile(func(bridge, hostsFile string) error {
+		data, err := os.ReadFile(hostsFile)
+		if err != nil {
+			return err
+		}
+		lines := strings.Split(string(data), "\n")
+		kept := lines[:0]
+		found := false
+		for _, line := range lines {
+			if strings.HasPrefix(line, mac+",") {
+				found = true
+				continue
+			}
+			if line != "" {
+				kept = append(kept, line)
+			}
+		}
+		if !found {
+			return nil
+		}
+		content := strings.Join(kept, "\n")
+		if content != "" {
+			content += "\n"
+		}
+		if err := os.WriteFile(hostsFile, []byte(content), 0644); err != nil {
+			return err
+		}
+		return m.reload(bridge)
+	})
+}
+
+// withEachBridgeHostsFile applies fn to every bridge's hosts file under
+// m.StateDir/dhcp. AddReservation/RemoveReservation don't know which
+// bridge a VM used (see the comment on AddReservation) — in the common
+// case of a single ch.network.bridge this is exactly one file, and fn is a
+// no-op for any other bridge's file that doesn't contain mac.
+func (m DnsmasqDHCPManager) withEachBridgeHostsFile(fn func(bridge, hostsFile string) error) error {
+	root := filepath.Join(m.StateDir, "dhcp")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if err := fn(e.Name(), m.hostsFile(e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// reload asks the bridge's dnsmasq process to reread its hosts file via
+// SIGHUP, dnsmasq's documented mechanism for picking up
+// --dhcp-hostsfile changes without a restart.
+func (m DnsmasqDHCPManager) reload(bridge string) error {
+	data, err := os.ReadFile(m.pidFile(bridge))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return nil
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return nil
+	}
+	if err := process.Signal(syscall.SIGHUP); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+// dhcpRange returns a usable DHCP range covering cidr, excluding the
+// gateway address (bridgeGatewayAndMask's first usable address, which the
+// bridge itself owns).
+func dhcpRange(cidr string) (start, end string, err error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", "", fmt.Errorf("only IPv4 CIDRs are supported, got %q", cidr)
+	}
+	ones, bits := ipnet.Mask.Size()
+	if bits != 32 || ones >= 31 {
+		return "", "", fmt.Errorf("CIDR %q is too small for a DHCP range", cidr)
+	}
+	broadcast := make(net.IP, 4)
+	for i := range ip4 {
+		broadcast[i] = ip4[i] | ^ipnet.Mask[i]
+	}
+	startIP := make(net.IP, 4)
+	copy(startIP, ip4)
+	startIP[3]++ // first address after the gateway (ip4 itself)
+	endIP := make(net.IP, 4)
+	copy(endIP, broadcast)
+	endIP[3]--
+	return startIP.String(), endIP.String(), nil
 }

--- a/internal/providerch/common_test.go
+++ b/internal/providerch/common_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -103,6 +104,56 @@ func TestConfigureAndBoot_PayloadShape(t *testing.T) {
 	assert.Equal(t, cfg.MacAddress, nets[0].(map[string]any)["mac"])
 }
 
+// TestConfigureAndBoot_WindowsPayloadShape mirrors
+// TestConfigureAndBoot_PayloadShape for the ch.os=windows path: Firmware
+// must land under payload.firmware (never payload.kernel), cpus.kvm_hyperv
+// must be set, and a second, read-only disk (the seed ISO) must be present.
+func TestConfigureAndBoot_WindowsPayloadShape(t *testing.T) {
+	sock := filepath.Join(shortTempDir(t), "api.sock")
+
+	var createBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/vm.create", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&createBody))
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v1/vm.boot", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	startUnixServer(t, sock, mux)
+
+	cfg := cloud.CHVMConfig{
+		KernelImage:  "/images/CLOUDHV.fd",
+		Firmware:     true,
+		KvmHyperv:    true,
+		RootfsPath:   "/vms/test/disk.raw",
+		SeedDiskPath: "/vms/test/seed.iso",
+		VCPUCount:    2,
+		MemSizeMib:   4096,
+		TapDevice:    "ch0123456789abc",
+		MacAddress:   "02:C4:00:00:00:00",
+	}
+	require.NoError(t, configureAndBoot(sock, cfg))
+
+	payload, ok := createBody["payload"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, cfg.KernelImage, payload["firmware"])
+	assert.NotContains(t, payload, "kernel", "a firmware boot must not also send a kernel path")
+	assert.NotContains(t, payload, "cmdline", "windows has no kernel cmdline")
+
+	cpus, ok := createBody["cpus"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, cpus["kvm_hyperv"])
+
+	disks, ok := createBody["disks"].([]any)
+	require.True(t, ok)
+	require.Len(t, disks, 2, "the seed ISO must be attached as a second disk")
+	assert.Equal(t, cfg.RootfsPath, disks[0].(map[string]any)["path"])
+	assert.Equal(t, cfg.SeedDiskPath, disks[1].(map[string]any)["path"])
+	assert.Equal(t, true, disks[1].(map[string]any)["readonly"])
+	assert.NotContains(t, disks[0].(map[string]any), "readonly", "the main disk must stay writable")
+}
+
 func TestConfigureAndBoot_CreateError(t *testing.T) {
 	sock := filepath.Join(shortTempDir(t), "api.sock")
 
@@ -132,4 +183,106 @@ func TestConfigureAndBoot_BootError(t *testing.T) {
 	err := configureAndBoot(sock, cloud.CHVMConfig{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "vm.boot")
+}
+
+func TestDHCPRange(t *testing.T) {
+	start, end, err := dhcpRange("172.17.0.1/24")
+	require.NoError(t, err)
+	assert.Equal(t, "172.17.0.2", start)
+	assert.Equal(t, "172.17.0.254", end)
+}
+
+func TestDHCPRange_TooSmall(t *testing.T) {
+	_, _, err := dhcpRange("172.17.0.1/31")
+	assert.Error(t, err)
+}
+
+func TestDHCPRange_InvalidCIDR(t *testing.T) {
+	_, _, err := dhcpRange("not-a-cidr")
+	assert.Error(t, err)
+}
+
+func TestConfigDriveUUID(t *testing.T) {
+	uuid := configDriveUUID("my-test-vm")
+	assert.Regexp(t, `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`, uuid)
+	assert.Equal(t, uuid, configDriveUUID("my-test-vm"), "must be deterministic")
+	assert.NotEqual(t, uuid, configDriveUUID("other-vm"))
+}
+
+// TestConfigDriveSeedPreparer_BuildSeedISO requires one of the ISO-building
+// tools (genisoimage/mkisofs/xorriso) on PATH — the same defensive skip
+// pattern providerfc's tests use for the `ip` binary.
+func TestConfigDriveSeedPreparer_BuildSeedISO(t *testing.T) {
+	found := false
+	for _, bin := range isoBuilders {
+		if _, err := exec.LookPath(bin); err == nil {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Skip("no ISO-building tool (genisoimage/mkisofs/xorriso) available")
+	}
+
+	dest := filepath.Join(t.TempDir(), "seed.iso")
+	prep := ConfigDriveSeedPreparer{}
+	require.NoError(t, prep.BuildSeedISO(dest, "win-test", "ssh-ed25519 AAAA test", "Administrator"))
+
+	info, err := os.Stat(dest)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+}
+
+func TestConfigDriveSeedPreparer_PrepareDisk(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "base.raw")
+	require.NoError(t, os.WriteFile(src, []byte("fake-windows-disk"), 0600))
+	dest := filepath.Join(t.TempDir(), "disk.raw")
+
+	prep := ConfigDriveSeedPreparer{}
+	require.NoError(t, prep.PrepareDisk(src, dest))
+
+	got, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-windows-disk", string(got))
+}
+
+func TestConfigDriveSeedPreparer_PrepareDisk_NoBaseImage(t *testing.T) {
+	prep := ConfigDriveSeedPreparer{}
+	assert.Error(t, prep.PrepareDisk("", filepath.Join(t.TempDir(), "disk.raw")))
+}
+
+// TestDnsmasqDHCPManager_ReservationRoundTrip exercises AddReservation/
+// RemoveReservation's hosts-file bookkeeping directly, without starting a
+// real dnsmasq process (EnsureDHCP is not called here — reload() is a
+// no-op when no dnsmasq pid file exists yet, which is exactly the state
+// this test runs in).
+func TestDnsmasqDHCPManager_ReservationRoundTrip(t *testing.T) {
+	stateDir := t.TempDir()
+	m := DnsmasqDHCPManager{StateDir: stateDir}
+	bridge := "chbr0"
+	require.NoError(t, os.MkdirAll(m.dhcpDir(bridge), 0755))
+	require.NoError(t, os.WriteFile(m.hostsFile(bridge), []byte{}, 0644))
+
+	require.NoError(t, m.AddReservation("02:C4:00:00:00:01", "172.17.0.2"))
+	require.NoError(t, m.AddReservation("02:C4:00:00:00:02", "172.17.0.3"))
+
+	// Regression check for a real bug: written lowercase regardless of
+	// input case, since dnsmasq's --dhcp-hostsfile matching is
+	// case-sensitive against the lowercase MAC a DHCP client actually
+	// sends — a mixed-case entry here silently never matches its own
+	// reservation and the guest gets a random pool address instead.
+	data, err := os.ReadFile(m.hostsFile(bridge))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "02:c4:00:00:00:01,172.17.0.2")
+	assert.Contains(t, string(data), "02:c4:00:00:00:02,172.17.0.3")
+	assert.NotContains(t, string(data), "02:C4")
+
+	// RemoveReservation must also match regardless of the case it's called
+	// with.
+	require.NoError(t, m.RemoveReservation("02:C4:00:00:00:01"))
+
+	data, err = os.ReadFile(m.hostsFile(bridge))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "00:00:00:01")
+	assert.Contains(t, string(data), "02:c4:00:00:00:02,172.17.0.3")
 }

--- a/pkg/cloud/ch.go
+++ b/pkg/cloud/ch.go
@@ -168,17 +168,17 @@ type ProviderCH struct {
 
 // chVM is the on-disk metadata persisted for each managed microVM.
 type chVM struct {
-	Name        string    `json:"name"`
-	PID         int       `json:"pid"`
-	SocketPath  string    `json:"socketPath"`
-	TapDevice   string    `json:"tapDevice"`
-	IPAddress   string    `json:"ipAddress"`
-	MacAddress  string    `json:"macAddress"`
-	VCPUCount   int64     `json:"vcpuCount"`
-	MemSizeMib  int64     `json:"memSizeMib"`
-	Status      string    `json:"status"`
-	KernelImage string    `json:"kernelImage"`
-	RootfsPath  string    `json:"rootfsPath"`
+	Name        string `json:"name"`
+	PID         int    `json:"pid"`
+	SocketPath  string `json:"socketPath"`
+	TapDevice   string `json:"tapDevice"`
+	IPAddress   string `json:"ipAddress"`
+	MacAddress  string `json:"macAddress"`
+	VCPUCount   int64  `json:"vcpuCount"`
+	MemSizeMib  int64  `json:"memSizeMib"`
+	Status      string `json:"status"`
+	KernelImage string `json:"kernelImage"`
+	RootfsPath  string `json:"rootfsPath"`
 	// OS is chOSWindows for a Windows guest, empty/"linux" otherwise.
 	OS string `json:"os,omitempty"`
 	// SeedDiskPath is the NoCloud seed ISO path for a Windows guest (see

--- a/pkg/cloud/ch.go
+++ b/pkg/cloud/ch.go
@@ -62,17 +62,76 @@ type CHConfig struct {
 	// StateDir is the directory onctl stores microVM state under
 	// (default /opt/ch).
 	StateDir string
+	// OS selects the guest boot path: "linux" (default) boots KernelImage
+	// as a direct Linux kernel; "windows" boots it as UEFI firmware
+	// (CLOUDHV.fd) instead. See chOSWindows.
+	OS string
 }
+
+// chOSWindows is the CHConfig.OS / chVM.OS value selecting the Windows
+// (UEFI firmware, no kernel cmdline, NoCloud seed ISO) boot path over the
+// default direct-kernel-boot Linux one. This integration has not been
+// exercised against a real cloud-hypervisor binary or a real Windows guest
+// (see docs/windows-ch.md) — treat it as unverified until someone has.
+const chOSWindows = "windows"
 
 // CHVMConfig describes a microVM to be configured and booted by a CHProcess.
 type CHVMConfig struct {
+	// KernelImage is a direct Linux kernel path (Firmware false) or a UEFI
+	// firmware path such as CLOUDHV.fd (Firmware true) — see PayloadConfig
+	// in internal/providerch/common.go for how this maps onto the wire.
 	KernelImage string
 	KernelArgs  string
-	RootfsPath  string
-	VCPUCount   int64
-	MemSizeMib  int64
-	TapDevice   string
-	MacAddress  string
+	// Firmware selects payload.firmware over payload.kernel/cmdline for
+	// KernelImage/KernelArgs — required for Windows guests, which have no
+	// direct-kernel-boot path.
+	Firmware bool
+	// KvmHyperv enables Hyper-V enlightenments (cpus.kvm_hyperv), required
+	// for Windows guests.
+	KvmHyperv  bool
+	RootfsPath string
+	// SeedDiskPath, if set, is attached as a second, read-only disk — a
+	// NoCloud-format seed ISO for cloudbase-init to apply hostname/SSH-key
+	// configuration to a Windows guest that onctl cannot write into
+	// directly (see WindowsGuestPreparer).
+	SeedDiskPath string
+	VCPUCount    int64
+	MemSizeMib   int64
+	TapDevice    string
+	MacAddress   string
+}
+
+// WindowsGuestPreparer prepares a per-VM Windows disk and its accompanying
+// NoCloud seed ISO. Unlike RootfsPreparer (ext4/debugfs-based), it never
+// writes into the guest disk itself — Windows disks are NTFS, which onctl
+// has no in-process tooling to modify — so all guest customization (
+// hostname, SSH public key) is delivered via the seed ISO instead, for
+// cloudbase-init (which must be pre-installed in the base image) to apply
+// at boot.
+type WindowsGuestPreparer interface {
+	// PrepareDisk creates destPath as a plain copy of baseImage (no
+	// modification), mirroring RootfsPreparer.Prepare's copy-not-mutate
+	// contract for the base image.
+	PrepareDisk(baseImage, destPath string) error
+	// BuildSeedISO creates destPath as a NoCloud-format ISO9660 volume
+	// (label "cidata") containing meta-data/user-data set from hostname,
+	// sshPublicKey and username.
+	BuildSeedISO(destPath, hostname, sshPublicKey, username string) error
+}
+
+// DHCPManager hands out DHCP leases on a bridge for guests that can't be
+// configured via a Linux kernel cmdline (i.e. Windows). Only used on the
+// chOSWindows path — the default Linux path keeps using the existing
+// ip=... kernel cmdline and never touches this.
+type DHCPManager interface {
+	// EnsureDHCP starts (or confirms already running) a DHCP server scoped
+	// to bridge/cidr, idempotent like NetworkManager.EnsureBridge.
+	EnsureDHCP(bridge, cidr string) error
+	// AddReservation hands mac a fixed lease of ip, so a guest's address
+	// always matches what onctl's metadata says it is.
+	AddReservation(mac, ip string) error
+	// RemoveReservation removes a reservation added by AddReservation.
+	RemoveReservation(mac string) error
 }
 
 // CHProcess starts and stops cloud-hypervisor VMM processes.
@@ -101,6 +160,10 @@ type ProviderCH struct {
 	Process CHProcess
 	Net     NetworkManager
 	Rootfs  RootfsPreparer
+	// WindowsGuest and DHCP are only used on the chOSWindows path; nil is
+	// fine for an all-Linux setup (the zero value of CHConfig.OS).
+	WindowsGuest WindowsGuestPreparer
+	DHCP         DHCPManager
 }
 
 // chVM is the on-disk metadata persisted for each managed microVM.
@@ -116,7 +179,12 @@ type chVM struct {
 	Status      string    `json:"status"`
 	KernelImage string    `json:"kernelImage"`
 	RootfsPath  string    `json:"rootfsPath"`
-	CreatedAt   time.Time `json:"createdAt"`
+	// OS is chOSWindows for a Windows guest, empty/"linux" otherwise.
+	OS string `json:"os,omitempty"`
+	// SeedDiskPath is the NoCloud seed ISO path for a Windows guest (see
+	// WindowsGuestPreparer), empty for a Linux guest.
+	SeedDiskPath string    `json:"seedDiskPath,omitempty"`
+	CreatedAt    time.Time `json:"createdAt"`
 }
 
 func (p ProviderCH) vmDir(name string) string {
@@ -214,10 +282,15 @@ func chTapName(vmName string) string {
 // chMAC derives a deterministic, locally-administered MAC address from the
 // VM name. Unlike fcMAC, the second octet can't spell out the provider name
 // in hex ("CH" isn't a valid hex byte — H isn't a hex digit), so it uses a
-// fixed placeholder octet instead.
+// fixed placeholder octet instead. Lowercase throughout (not just "c4"):
+// dnsmasq's --dhcp-hostsfile reservation matching (used on the Windows
+// path, see DHCPManager) is case-sensitive against the lowercase-normalized
+// MAC a DHCP client actually sends, so a mixed-case address here silently
+// never matches its own reservation and the guest gets a random pool
+// address instead of the one onctl's metadata says it has.
 func chMAC(vmName string) string {
 	sum := md5.Sum([]byte(vmName))
-	return fmt.Sprintf("02:C4:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
+	return fmt.Sprintf("02:c4:%02x:%02x:%02x:%02x", sum[0], sum[1], sum[2], sum[3])
 }
 
 // usedIPs returns the set of IP addresses already assigned to managed microVMs.
@@ -350,10 +423,30 @@ func (p ProviderCH) Deploy(server Vm) (Vm, error) {
 		sshPublicKey = strings.TrimSpace(string(data))
 	}
 
-	rootfsPath := filepath.Join(dir, "rootfs.ext4")
-	if err := p.Rootfs.Prepare(rootfsImage, rootfsPath, sanitizeGuestHostname(server.Name), sshPublicKey, username); err != nil {
-		_ = os.RemoveAll(dir)
-		return Vm{}, fmt.Errorf("failed to prepare rootfs: %w", err)
+	isWindows := p.Config.OS == chOSWindows
+
+	var rootfsPath, seedDiskPath string
+	if isWindows {
+		if p.WindowsGuest == nil {
+			_ = os.RemoveAll(dir)
+			return Vm{}, errors.New("ch.os=windows requires a WindowsGuestPreparer to be configured (internal error)")
+		}
+		rootfsPath = filepath.Join(dir, "disk.raw")
+		if err := p.WindowsGuest.PrepareDisk(rootfsImage, rootfsPath); err != nil {
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to prepare Windows disk: %w", err)
+		}
+		seedDiskPath = filepath.Join(dir, "seed.iso")
+		if err := p.WindowsGuest.BuildSeedISO(seedDiskPath, sanitizeGuestHostname(server.Name), sshPublicKey, username); err != nil {
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to build seed ISO: %w", err)
+		}
+	} else {
+		rootfsPath = filepath.Join(dir, "rootfs.ext4")
+		if err := p.Rootfs.Prepare(rootfsImage, rootfsPath, sanitizeGuestHostname(server.Name), sshPublicKey, username); err != nil {
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to prepare rootfs: %w", err)
+		}
 	}
 
 	bridge := p.Config.Bridge
@@ -381,51 +474,84 @@ func (p ProviderCH) Deploy(server Vm) (Vm, error) {
 		_ = os.RemoveAll(dir)
 		return Vm{}, err
 	}
-	gateway, mask, err := bridgeGatewayAndMask(cidr)
-	if err != nil {
-		_ = p.Net.DeleteTap(tapDevice)
-		_ = os.RemoveAll(dir)
-		return Vm{}, err
-	}
-
-	kernelArgs := strings.TrimSpace(p.Config.KernelArgs)
-	if kernelArgs == "" {
-		kernelArgs = defaultCHKernelArgs
-	}
-	kernelArgs = fmt.Sprintf("%s ip=%s::%s:%s::eth0:off", kernelArgs, ip, gateway, mask)
-
 	mac := chMAC(server.Name)
+
+	var kernelArgs string
+	if isWindows {
+		// Windows has no Linux kernel cmdline to parse networking from;
+		// the guest gets its address via DHCP instead (see DHCPManager).
+		// The seed ISO's meta-data still carries the hostname and SSH key
+		// for cloudbase-init to apply.
+		if p.DHCP == nil {
+			_ = p.Net.DeleteTap(tapDevice)
+			_ = os.RemoveAll(dir)
+			return Vm{}, errors.New("ch.os=windows requires a DHCPManager to be configured (internal error)")
+		}
+		if err := p.DHCP.EnsureDHCP(bridge, cidr); err != nil {
+			_ = p.Net.DeleteTap(tapDevice)
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to set up DHCP on %q: %w", bridge, err)
+		}
+		if err := p.DHCP.AddReservation(mac, ip); err != nil {
+			_ = p.Net.DeleteTap(tapDevice)
+			_ = os.RemoveAll(dir)
+			return Vm{}, fmt.Errorf("failed to reserve DHCP lease for %s: %w", ip, err)
+		}
+	} else {
+		gateway, mask, err := bridgeGatewayAndMask(cidr)
+		if err != nil {
+			_ = p.Net.DeleteTap(tapDevice)
+			_ = os.RemoveAll(dir)
+			return Vm{}, err
+		}
+		kernelArgs = strings.TrimSpace(p.Config.KernelArgs)
+		if kernelArgs == "" {
+			kernelArgs = defaultCHKernelArgs
+		}
+		kernelArgs = fmt.Sprintf("%s ip=%s::%s:%s::eth0:off", kernelArgs, ip, gateway, mask)
+	}
+
 	socketPath := filepath.Join(dir, "ch.sock")
 	logFile := filepath.Join(dir, "ch.log")
 
 	pid, err := p.Process.Start(socketPath, CHVMConfig{
-		KernelImage: kernelImage,
-		KernelArgs:  kernelArgs,
-		RootfsPath:  rootfsPath,
-		VCPUCount:   vcpu,
-		MemSizeMib:  mem,
-		TapDevice:   tapDevice,
-		MacAddress:  mac,
+		KernelImage:  kernelImage,
+		KernelArgs:   kernelArgs,
+		Firmware:     isWindows,
+		KvmHyperv:    isWindows,
+		RootfsPath:   rootfsPath,
+		SeedDiskPath: seedDiskPath,
+		VCPUCount:    vcpu,
+		MemSizeMib:   mem,
+		TapDevice:    tapDevice,
+		MacAddress:   mac,
 	}, logFile)
 	if err != nil {
+		if isWindows {
+			if rmErr := p.DHCP.RemoveReservation(mac); rmErr != nil {
+				log.Println("[DEBUG] failed to remove DHCP reservation for " + mac + ": " + rmErr.Error())
+			}
+		}
 		_ = p.Net.DeleteTap(tapDevice)
 		_ = os.RemoveAll(dir)
 		return Vm{}, fmt.Errorf("failed to start microVM: %w", err)
 	}
 
 	vm := chVM{
-		Name:        server.Name,
-		PID:         pid,
-		SocketPath:  socketPath,
-		TapDevice:   tapDevice,
-		IPAddress:   ip,
-		MacAddress:  mac,
-		VCPUCount:   vcpu,
-		MemSizeMib:  mem,
-		Status:      chStatusRunning,
-		KernelImage: kernelImage,
-		RootfsPath:  rootfsPath,
-		CreatedAt:   time.Now(),
+		Name:         server.Name,
+		PID:          pid,
+		SocketPath:   socketPath,
+		TapDevice:    tapDevice,
+		IPAddress:    ip,
+		MacAddress:   mac,
+		VCPUCount:    vcpu,
+		MemSizeMib:   mem,
+		Status:       chStatusRunning,
+		KernelImage:  kernelImage,
+		RootfsPath:   rootfsPath,
+		OS:           p.Config.OS,
+		SeedDiskPath: seedDiskPath,
+		CreatedAt:    time.Now(),
 	}
 	if err := saveCHMetadata(p.metadataPath(server.Name), vm); err != nil {
 		return Vm{}, fmt.Errorf("microVM started but failed to persist metadata: %w", err)
@@ -458,6 +584,13 @@ func (p ProviderCH) Destroy(server Vm) error {
 			log.Println("[DEBUG] failed to delete tap device " + vm.TapDevice + ": " + err.Error())
 		}
 	}
+	if vm.OS == chOSWindows && vm.MacAddress != "" && p.DHCP != nil {
+		if err := p.DHCP.RemoveReservation(vm.MacAddress); err != nil {
+			log.Println("[DEBUG] failed to remove DHCP reservation for " + vm.MacAddress + ": " + err.Error())
+		}
+	}
+	// The seed ISO (if any) lives under vmDir alongside everything else
+	// removed below; no separate cleanup needed.
 	return os.RemoveAll(p.vmDir(server.Name))
 }
 

--- a/pkg/cloud/ch_test.go
+++ b/pkg/cloud/ch_test.go
@@ -20,10 +20,13 @@ type fakeCHProcess struct {
 	stopCalls  []int
 	running    map[int]bool
 	notOwned   map[int]bool
+	// lastCfg is the CHVMConfig passed to the most recent Start call.
+	lastCfg CHVMConfig
 }
 
-func (f *fakeCHProcess) Start(_ string, _ CHVMConfig, _ string) (int, error) {
+func (f *fakeCHProcess) Start(_ string, cfg CHVMConfig, _ string) (int, error) {
 	f.startCalls++
+	f.lastCfg = cfg
 	if f.startErr != nil {
 		return 0, f.startErr
 	}
@@ -104,7 +107,10 @@ func TestCHTapName(t *testing.T) {
 
 func TestCHMAC(t *testing.T) {
 	mac := chMAC("my-test-vm")
-	assert.Regexp(t, `^02:C4:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}$`, mac)
+	// Lowercase throughout, not just valid hex: dnsmasq's --dhcp-hostsfile
+	// reservation matching is case-sensitive against the lowercase MAC a
+	// DHCP client actually sends (see chMAC's doc comment).
+	assert.Regexp(t, `^02:c4:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}$`, mac)
 	assert.Equal(t, mac, chMAC("my-test-vm"))
 	// Regression check for a bug caught in review: every octet must be
 	// valid hex, or Cloud Hypervisor rejects the vm.create payload outright.
@@ -301,4 +307,122 @@ func TestProviderCH_CreateSSHKey_Invalid(t *testing.T) {
 
 	_, err := p.CreateSSHKey(keyFile)
 	assert.Error(t, err)
+}
+
+// fakeWindowsGuestPreparer is a test double for WindowsGuestPreparer.
+type fakeWindowsGuestPreparer struct {
+	diskCalls int
+	isoCalls  int
+	hostnames []string
+}
+
+func (f *fakeWindowsGuestPreparer) PrepareDisk(_, destPath string) error {
+	f.diskCalls++
+	return os.WriteFile(destPath, []byte("fake-disk"), 0600)
+}
+
+func (f *fakeWindowsGuestPreparer) BuildSeedISO(destPath, hostname, _, _ string) error {
+	f.isoCalls++
+	f.hostnames = append(f.hostnames, hostname)
+	return os.WriteFile(destPath, []byte("fake-seed"), 0600)
+}
+
+// fakeDHCPManager is a test double for DHCPManager.
+type fakeDHCPManager struct {
+	ensureCalls  []string // bridge names
+	reservations map[string]string
+	removed      []string
+}
+
+func (f *fakeDHCPManager) EnsureDHCP(bridge, _ string) error {
+	f.ensureCalls = append(f.ensureCalls, bridge)
+	return nil
+}
+
+func (f *fakeDHCPManager) AddReservation(mac, ip string) error {
+	if f.reservations == nil {
+		f.reservations = map[string]string{}
+	}
+	f.reservations[mac] = ip
+	return nil
+}
+
+func (f *fakeDHCPManager) RemoveReservation(mac string) error {
+	f.removed = append(f.removed, mac)
+	delete(f.reservations, mac)
+	return nil
+}
+
+// newTestCHProviderWindows is newTestCHProvider's counterpart for the
+// ch.os=windows path.
+func newTestCHProviderWindows(t *testing.T) (ProviderCH, *fakeCHProcess, *fakeNetworkManager, *fakeWindowsGuestPreparer, *fakeDHCPManager) {
+	t.Helper()
+	proc := &fakeCHProcess{pid: 12345}
+	net := &fakeNetworkManager{}
+	winGuest := &fakeWindowsGuestPreparer{}
+	dhcp := &fakeDHCPManager{}
+	p := ProviderCH{
+		Config: CHConfig{
+			KernelImage: "/images/CLOUDHV.fd",
+			RootfsImage: "/images/windows.raw",
+			VCPUCount:   2,
+			MemSizeMib:  4096,
+			Bridge:      "chbr0",
+			CIDR:        "172.17.0.1/24",
+			Username:    "Administrator",
+			StateDir:    t.TempDir(),
+			OS:          chOSWindows,
+		},
+		Process:      proc,
+		Net:          net,
+		WindowsGuest: winGuest,
+		DHCP:         dhcp,
+	}
+	return p, proc, net, winGuest, dhcp
+}
+
+// TestProviderCH_Deploy_Windows verifies the ch.os=windows boot path: no
+// Linux kernel cmdline is generated, CHVMConfig.Firmware/KvmHyperv are set,
+// a seed ISO is built and attached, and the guest's DHCP reservation is
+// added instead of a static ip= kernel argument.
+func TestProviderCH_Deploy_Windows(t *testing.T) {
+	p, proc, netMgr, winGuest, dhcp := newTestCHProviderWindows(t)
+	pubKeyFile := writeTestPublicKey(t)
+
+	vm, err := p.Deploy(Vm{Name: "win-vm", SSHKeyID: pubKeyFile})
+	require.NoError(t, err)
+
+	assert.Equal(t, "running", vm.Status)
+	assert.Equal(t, 1, proc.startCalls)
+	assert.True(t, proc.lastCfg.Firmware, "windows guests must boot via UEFI firmware, not a direct kernel")
+	assert.True(t, proc.lastCfg.KvmHyperv, "windows guests require Hyper-V enlightenments")
+	assert.Empty(t, proc.lastCfg.KernelArgs, "windows has no Linux kernel cmdline to parse")
+	assert.Equal(t, "/images/CLOUDHV.fd", proc.lastCfg.KernelImage, "reinterpreted as the firmware path")
+	assert.NotEmpty(t, proc.lastCfg.SeedDiskPath)
+
+	assert.Equal(t, 1, winGuest.diskCalls)
+	assert.Equal(t, 1, winGuest.isoCalls)
+	assert.Equal(t, []string{"win-vm"}, winGuest.hostnames)
+
+	assert.Equal(t, []string{"chbr0"}, dhcp.ensureCalls)
+	mac := chMAC("win-vm")
+	assert.Equal(t, "172.17.0.2", dhcp.reservations[mac])
+
+	assert.Equal(t, []string{"chbr0"}, netMgr.bridges)
+
+	meta, err := loadCHMetadata(p.metadataPath("win-vm"))
+	require.NoError(t, err)
+	assert.Equal(t, chOSWindows, meta.OS)
+	assert.NotEmpty(t, meta.SeedDiskPath)
+}
+
+// TestProviderCH_Destroy_Windows verifies Destroy removes the guest's DHCP
+// reservation on top of the usual tap/state cleanup.
+func TestProviderCH_Destroy_Windows(t *testing.T) {
+	p, _, _, _, dhcp := newTestCHProviderWindows(t)
+	_, err := p.Deploy(Vm{Name: "win-vm"})
+	require.NoError(t, err)
+
+	require.NoError(t, p.Destroy(Vm{Name: "win-vm"}))
+	assert.Contains(t, dhcp.removed, chMAC("win-vm"))
 }


### PR DESCRIPTION
## Summary
- Adds a Windows boot mode to the existing `ch` provider (UEFI firmware + `kvm_hyperv`, a NoCloud/OpenStack-format seed ISO for cloudbase-init, and a DHCP-based networking path via a new `--ch-os windows` flag) — the Linux `ch` path is unchanged.
- Verified end-to-end against real `cloud-hypervisor` v53.0 on a real Windows Server 2025 image: a completely unmodified `onctl create` → `onctl ssh` → `onctl destroy` cycle works with zero manual intervention.
- Fixes two real bugs found during that verification, both on the new Windows/DHCP path only (the Linux `ch` path never used DHCP): `chMAC()` emitted a mixed-case MAC address that dnsmasq's `--dhcp-hostsfile` matching silently failed to honor, and `DnsmasqDHCPManager` shared dnsmasq's system-wide lease file with any other dnsmasq on the host instead of a private one.
- `TESTING-ch-windows.md` documents the full base-image prep recipe and three more gotchas that are Windows/cloudbase-init/OpenSSH quirks rather than onctl bugs (boot-critical `viostor` registration, the admin-account `authorized_keys` special case, and the OpenSSH firewall rule's default profile scope).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./pkg/cloud/... ./internal/providerch/...` all pass
- [x] Real end-to-end run against `cloud-hypervisor` v53.0 + Windows Server 2025: `onctl create --ch-os windows ...` → `onctl ssh -- whoami` (`win2025-clean\administrator`) → `onctl destroy` (see `TESTING-ch-windows.md`)
- [x] Existing Linux `ch` path unaffected (same test suite, no behavior change on that path)
- [ ] Windows 11 — not tested (TPM/Secure Boot bypass documented but unverified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iVNj3mykz8m7QfuxWN3ae