### PR TITLE
Add a real SSH-reachability signal to fc/ch's List()

### DIFF
--- a/pkg/cloud/ch.go
+++ b/pkg/cloud/ch.go
@@ -185,6 +185,18 @@ type chVM struct {
 	// WindowsGuestPreparer), empty for a Linux guest.
 	SeedDiskPath string    `json:"seedDiskPath,omitempty"`
 	CreatedAt    time.Time `json:"createdAt"`
+	// SSHPort is the guest's SSH port, persisted so List()'s SSHReady
+	// probe (see reconcileSSHReady) targets the right one instead of
+	// assuming 22 -- falls back to 22 itself when zero (a legacy record
+	// predating this field, or a caller that never set Vm.SSHPort).
+	SSHPort int `json:"sshPort,omitempty"`
+	// SSHReady is set once List() confirms this VM's SSH port is
+	// reachable (see cloud.ProbeSSHReady) -- never reset back to false
+	// once true, since this only exists to distinguish "still booting"
+	// from "actually ready," not to track live reachability from moment
+	// to moment (that's what Status/isAlive already do, via a different,
+	// cheaper signal: process liveness, not a network probe).
+	SSHReady bool `json:"sshReady,omitempty"`
 }
 
 func (p ProviderCH) vmDir(name string) string {
@@ -254,6 +266,8 @@ func mapCHVM(vm chVM) Vm {
 		Type:      fmt.Sprintf("%dvcpu-%dmb", vm.VCPUCount, vm.MemSizeMib),
 		Image:     vm.RootfsPath,
 		Status:    vm.Status,
+		SSHPort:   vm.SSHPort,
+		SSHReady:  vm.SSHReady,
 		CreatedAt: vm.CreatedAt,
 	}
 }
@@ -537,6 +551,10 @@ func (p ProviderCH) Deploy(server Vm) (Vm, error) {
 		return Vm{}, fmt.Errorf("failed to start microVM: %w", err)
 	}
 
+	sshPort := server.SSHPort
+	if sshPort == 0 {
+		sshPort = 22
+	}
 	vm := chVM{
 		Name:         server.Name,
 		PID:          pid,
@@ -551,6 +569,7 @@ func (p ProviderCH) Deploy(server Vm) (Vm, error) {
 		RootfsPath:   rootfsPath,
 		OS:           p.Config.OS,
 		SeedDiskPath: seedDiskPath,
+		SSHPort:      sshPort,
 		CreatedAt:    time.Now(),
 	}
 	if err := saveCHMetadata(p.metadataPath(server.Name), vm); err != nil {
@@ -615,11 +634,33 @@ func (p ProviderCH) List() (VmList, error) {
 	if err != nil {
 		return VmList{}, err
 	}
+	p.reconcileSSHReady(all)
 	var list VmList
 	for _, vm := range all {
 		list.List = append(list.List, mapCHVM(vm))
 	}
 	return list, nil
+}
+
+// reconcileSSHReady TCP-probes (see cloud.ProbeSSHReady) every running,
+// not-yet-SSHReady VM in all, updating both the in-memory slice (so this
+// call's own List() result reflects newly-ready VMs immediately, not just
+// the next one) and, for any that answered, persisting SSHReady=true to
+// disk so future List() calls skip probing them again.
+func (p ProviderCH) reconcileSSHReady(all []chVM) {
+	candidates := make([]Vm, len(all))
+	for i, vm := range all {
+		if vm.Status == chStatusRunning && !vm.SSHReady {
+			candidates[i] = Vm{IP: vm.IPAddress, SSHPort: vm.SSHPort}
+		}
+	}
+	ready := ProbeSSHReady(candidates)
+	for i := range ready {
+		all[i].SSHReady = true
+		if err := saveCHMetadata(p.metadataPath(all[i].Name), all[i]); err != nil {
+			log.Println("[DEBUG] failed to persist SSHReady for " + all[i].Name + ": " + err.Error())
+		}
+	}
 }
 
 // ListPaused always returns an empty list: this provider has no pause support.

--- a/pkg/cloud/ch_test.go
+++ b/pkg/cloud/ch_test.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -236,6 +237,65 @@ func TestProviderCH_GetByName_ReconcilesDeadProcess(t *testing.T) {
 	vm, err := p.GetByName("test-vm")
 	require.NoError(t, err)
 	assert.Equal(t, chStatusDead, vm.Status)
+}
+
+// TestProviderCH_List_MarksSSHReadyWhenReachable is a regression test for
+// the "which buttons should the dashboard show" gap: Status alone only
+// means "the cloud-hypervisor process is alive," not "the guest actually
+// finished booting" (chStatusRunning is set at Deploy time, well before a
+// Windows guest's cloudbase-init run finishes) -- List() must also
+// TCP-probe and report SSHReady so a consumer like boxctl-vms can tell
+// the two apart.
+func TestProviderCH_List_MarksSSHReadyWhenReachable(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	host, port, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+
+	// Simulate the VM's real, DHCP/static-assigned IP landing on our fake
+	// listener -- List() has no way to know this address is "special", it
+	// just probes whatever IPAddress metadata.json already has.
+	vm, err := loadCHMetadata(p.metadataPath("test-vm"))
+	require.NoError(t, err)
+	vm.IPAddress = host
+	var portNum int
+	_, err = fmt.Sscanf(port, "%d", &portNum)
+	require.NoError(t, err)
+	vm.SSHPort = portNum
+	require.NoError(t, saveCHMetadata(p.metadataPath("test-vm"), vm))
+
+	list, err := p.List()
+	require.NoError(t, err)
+	require.Len(t, list.List, 1)
+	assert.True(t, list.List[0].SSHReady, "List() must report SSHReady once the port is reachable")
+
+	// Must also have persisted, not just been reflected in this one call's
+	// return value -- a later List() shouldn't need to re-probe (and
+	// couldn't tell the difference if it silently didn't persist).
+	reloaded, err := loadCHMetadata(p.metadataPath("test-vm"))
+	require.NoError(t, err)
+	assert.True(t, reloaded.SSHReady)
+}
+
+// TestProviderCH_List_SSHReadyFalseUntilReachable checks the negative
+// case: a freshly deployed VM (fake test harness never assigns a real,
+// reachable IP) is reported not-ready rather than defaulting to ready --
+// the whole point is to distinguish "still booting" from "actually up",
+// so a false positive here would defeat it.
+func TestProviderCH_List_SSHReadyFalseUntilReachable(t *testing.T) {
+	p, _, _, _ := newTestCHProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	list, err := p.List()
+	require.NoError(t, err)
+	require.Len(t, list.List, 1)
+	assert.False(t, list.List[0].SSHReady)
 }
 
 func TestProviderCH_GetByName_NotFound(t *testing.T) {

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -2,7 +2,9 @@ package cloud
 
 import (
 	"fmt"
+	"net"
 	"reflect"
+	"sync"
 	"time"
 )
 
@@ -34,6 +36,18 @@ type Vm struct {
 	Image string `yaml:"image"`
 	// Status is the status of the instance
 	Status string
+	// SSHReady reports whether this VM's SSH port has been confirmed
+	// reachable at least once (see ProbeTCP and each local provider's
+	// List(), which is where this is actually computed for fc/ch — the
+	// remote-cloud providers below never set it, since they have no
+	// equivalent "process alive but guest still booting" gap: their own
+	// Deploy already blocks on WaitForCloudInit/WaitForSSH before ever
+	// returning, so by the time such a VM shows up in List() at all, it
+	// was already fully ready). Status alone only reflects "the VMM
+	// process is alive," not "the guest OS finished booting" -- a
+	// consumer that needs to know when it's actually safe to open a
+	// terminal (e.g. boxctl-vms) should gate on this, not on Status.
+	SSHReady bool
 	// Location is the location of the instance
 	Location string
 	// SSHKeyID is the ID of the SSH key
@@ -55,6 +69,72 @@ type CostStruct struct {
 	CostPerHour     float64
 	CostPerMonth    float64
 	AccumulatedCost float64
+}
+
+// ProbeTCP reports whether a TCP connection to addr ("host:port") succeeds
+// within timeout. Used by fc/ch's List() to compute Vm.SSHReady -- a plain
+// TCP connect, not a full SSH handshake: WaitForSSH (internal/tools/
+// remote-run.go), used at create time, already does the real handshake, but
+// that needs the operator's actual SSH private key material threaded all
+// the way into this package (pkg/cloud currently has none, by design --
+// key handling lives in cmd/ and internal/tools) and, worse, its key-
+// parsing path can block on an interactive passphrase prompt on stdin if
+// the key is passphrase-protected. That's fine once, synchronously, in a
+// CLI command a human is sitting at; it would be a real bug here, since
+// List() also runs from a long-running background poll (see boxctl-vms-
+// agent.sh) with no terminal attached, where blocking on stdin would hang
+// forever. A successful TCP connect to the SSH port is a materially
+// weaker signal (it doesn't prove key auth would succeed, only that
+// sshd/OpenSSH is listening) but is what actually closes the multi-minute
+// gap this exists for -- the "guest hasn't even finished booting /
+// networking isn't up yet" phase -- without any of the above risk.
+func ProbeTCP(addr string, timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// probeTimeout bounds each individual TCP probe ProbeSSHReady issues.
+// Short, since these run inline in List() (called on every `onctl ls`,
+// including a periodic poll every few seconds -- see boxctl-vms-agent.sh)
+// and every not-yet-ready VM is probed concurrently, so this is close to
+// the actual worst-case added latency, not a per-VM sum.
+const probeTimeout = 300 * time.Millisecond
+
+// ProbeSSHReady concurrently TCP-probes every candidate VM's IP:port (see
+// ProbeTCP) and returns the set of indices (into candidates) that answered
+// within probeTimeout. Shared by ProviderFC.List and ProviderCH.List,
+// which each know how to persist SSHReady=true back to their own
+// on-disk metadata for the returned indices -- this function has no
+// opinion on persistence, just on which candidates are currently
+// reachable.
+func ProbeSSHReady(candidates []Vm) map[int]bool {
+	ready := make(map[int]bool)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i, vm := range candidates {
+		if vm.IP == "" {
+			continue
+		}
+		port := vm.SSHPort
+		if port == 0 {
+			port = 22
+		}
+		wg.Add(1)
+		go func(i int, addr string) {
+			defer wg.Done()
+			if ProbeTCP(addr, probeTimeout) {
+				mu.Lock()
+				ready[i] = true
+				mu.Unlock()
+			}
+		}(i, net.JoinHostPort(vm.IP, fmt.Sprint(port)))
+	}
+	wg.Wait()
+	return ready
 }
 
 func (v Vm) String() string {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1,11 +1,14 @@
 package cloud
 
 import (
+	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVmString(t *testing.T) {
@@ -93,4 +96,38 @@ func TestCostStruct(t *testing.T) {
 	assert.InDelta(t, 0.05, c.CostPerHour, 0.0001)
 	assert.InDelta(t, 36.0, c.CostPerMonth, 0.0001)
 	assert.InDelta(t, 2.5, c.AccumulatedCost, 0.0001)
+}
+
+func TestProbeTCP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+
+	assert.True(t, ProbeTCP(ln.Addr().String(), time.Second), "a real listener must probe reachable")
+
+	// 10.255.255.1 is a non-routable address reserved for exactly this
+	// (blackholes rather than fast-refusing, so this also exercises the
+	// timeout path, not just "connection refused").
+	assert.False(t, ProbeTCP("10.255.255.1:22", 100*time.Millisecond))
+}
+
+func TestProbeSSHReady(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = ln.Close() }()
+	_, portStr, err := net.SplitHostPort(ln.Addr().String())
+	require.NoError(t, err)
+	var port int
+	_, err = fmt.Sscanf(portStr, "%d", &port)
+	require.NoError(t, err)
+
+	candidates := []Vm{
+		{IP: "127.0.0.1", SSHPort: port},  // reachable
+		{IP: "10.255.255.1", SSHPort: 22}, // unreachable (probeTimeout bounds this)
+		{IP: ""},                          // not a real candidate -- must be skipped, not probed
+	}
+	ready := ProbeSSHReady(candidates)
+	assert.True(t, ready[0], "index 0 (real listener) must be reported ready")
+	assert.False(t, ready[1], "index 1 (unreachable) must not be reported ready")
+	assert.False(t, ready[2], "index 2 (no IP) must not be reported ready")
 }

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -226,6 +226,18 @@ type fcVM struct {
 	// VM name) is all "resume elsewhere" needs.
 	SnapshotStatePath   string `json:"snapshotStatePath,omitempty"`
 	SnapshotMemFilePath string `json:"snapshotMemFilePath,omitempty"`
+	// SSHPort is the guest's SSH port, persisted so List()'s SSHReady
+	// probe (see reconcileSSHReady) targets the right one instead of
+	// assuming 22 -- falls back to 22 itself when zero (a legacy record
+	// predating this field, or a caller that never set Vm.SSHPort).
+	SSHPort int `json:"sshPort,omitempty"`
+	// SSHReady is set once List() confirms this VM's SSH port is
+	// reachable (see cloud.ProbeSSHReady) -- never reset back to false
+	// once true, since this only exists to distinguish "still booting"
+	// from "actually ready," not to track live reachability from moment
+	// to moment (that's what Status/isAlive already do, via a different,
+	// cheaper signal: process liveness, not a network probe).
+	SSHReady bool `json:"sshReady,omitempty"`
 }
 
 func (p ProviderFC) vmDir(name string) string {
@@ -307,6 +319,8 @@ func mapFCVM(vm fcVM) Vm {
 		Type:      fmt.Sprintf("%dvcpu-%dmb", vm.VCPUCount, vm.MemSizeMib),
 		Image:     vm.RootfsPath,
 		Status:    vm.Status,
+		SSHPort:   vm.SSHPort,
+		SSHReady:  vm.SSHReady,
 		CreatedAt: vm.CreatedAt,
 	}
 }
@@ -632,6 +646,10 @@ func (p ProviderFC) Deploy(server Vm) (Vm, error) {
 		return Vm{}, fmt.Errorf("failed to start microVM: %w", err)
 	}
 
+	sshPort := server.SSHPort
+	if sshPort == 0 {
+		sshPort = 22
+	}
 	vm := fcVM{
 		Name:        server.Name,
 		PID:         pid,
@@ -646,6 +664,7 @@ func (p ProviderFC) Deploy(server Vm) (Vm, error) {
 		RootfsPath:  rootfsPath,
 		CachePath:   cachePath,
 		CacheImage:  p.Config.CacheImage,
+		SSHPort:     sshPort,
 		CreatedAt:   time.Now(),
 	}
 	if err := saveFCMetadata(p.metadataPath(server.Name), vm); err != nil {
@@ -873,6 +892,7 @@ func (p ProviderFC) List() (VmList, error) {
 	if err != nil {
 		return VmList{}, err
 	}
+	p.reconcileSSHReady(all)
 	var list VmList
 	for _, vm := range all {
 		if vm.Status == fcStatusPaused {
@@ -881,6 +901,24 @@ func (p ProviderFC) List() (VmList, error) {
 		list.List = append(list.List, mapFCVM(vm))
 	}
 	return list, nil
+}
+
+// reconcileSSHReady mirrors ProviderCH.reconcileSSHReady -- see its doc
+// comment.
+func (p ProviderFC) reconcileSSHReady(all []fcVM) {
+	candidates := make([]Vm, len(all))
+	for i, vm := range all {
+		if vm.Status == fcStatusRunning && !vm.SSHReady {
+			candidates[i] = Vm{IP: vm.IPAddress, SSHPort: vm.SSHPort}
+		}
+	}
+	ready := ProbeSSHReady(candidates)
+	for i := range ready {
+		all[i].SSHReady = true
+		if err := saveFCMetadata(p.metadataPath(all[i].Name), all[i]); err != nil {
+			log.Println("[DEBUG] failed to persist SSHReady for " + all[i].Name + ": " + err.Error())
+		}
+	}
 }
 
 // ListPaused returns all paused managed microVMs.


### PR DESCRIPTION
## Summary
- `Status` only ever reflected "the VMM process is alive" (set at Deploy time, checked afterward via `isAlive`'s process-liveness check), never "the guest OS actually finished booting" -- for a Windows/`ch` guest, that gap can be minutes wide, but any consumer polling `onctl ls` mid-boot has no way to tell a genuinely usable VM apart from one still booting.
- `List()` now also TCP-probes each running VM's SSH port (300ms timeout, concurrently across every not-yet-confirmed VM) and reports the result as a new `Vm.SSHReady` field, persisting `true` once confirmed so it's never re-probed again.
- Deliberately a TCP-connect check, not a full SSH auth handshake: reusing `WaitForSSH`'s handshake would need the operator's private key material threaded into `pkg/cloud`, and its passphrase-prompt fallback can block on stdin -- fine synchronously in a CLI command, a real bug in `List()`, which also runs unattended from a periodic poll (see `boxctl-vms-agent.sh`).
- `fc`/`ch` now persist each VM's actual `SSHPort` (previously implicit/hardcoded as 22 nowhere in particular) so the probe targets the right one.

Found while adding a "don't show Terminal until the VM is actually ready" indicator to the boxctl-vms dashboard -- discovered `onctl ls` had no signal for that distinction at all.

## Test plan
- [x] `go build ./...`, `go vet ./pkg/cloud/...`, `gofmt -l` clean
- [x] `go test ./pkg/cloud/...` -- new tests cover `ProbeTCP`/`ProbeSSHReady` directly (reachable/unreachable/no-IP), and `ch`'s `List()` end-to-end against a real local listener (becomes `SSHReady`, persists to metadata.json) and against a freshly-deployed VM with no reachable IP (stays `false`, no false positive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)