### PR TITLE
Skip the SSHReady TCP probe for fc (Firecracker boots too fast to need it)

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -36,17 +36,19 @@ type Vm struct {
 	Image string `yaml:"image"`
 	// Status is the status of the instance
 	Status string
-	// SSHReady reports whether this VM's SSH port has been confirmed
-	// reachable at least once (see ProbeTCP and each local provider's
-	// List(), which is where this is actually computed for fc/ch — the
-	// remote-cloud providers below never set it, since they have no
-	// equivalent "process alive but guest still booting" gap: their own
-	// Deploy already blocks on WaitForCloudInit/WaitForSSH before ever
-	// returning, so by the time such a VM shows up in List() at all, it
-	// was already fully ready). Status alone only reflects "the VMM
-	// process is alive," not "the guest OS finished booting" -- a
-	// consumer that needs to know when it's actually safe to open a
-	// terminal (e.g. boxctl-vms) should gate on this, not on Status.
+	// SSHReady reports whether it's actually safe to open a terminal to
+	// this VM -- Status alone only reflects "the VMM process is alive,"
+	// not "the guest OS finished booting," and for a slow-booting guest
+	// that gap can be minutes wide. Only ch (ProviderCH.reconcileSSHReady)
+	// really TCP-probes for this (see ProbeTCP/ProbeSSHReady), since a
+	// Cloud Hypervisor/Windows guest can take that long. fc derives it
+	// straight from Status instead (mapFCVM) -- a Firecracker microVM
+	// boots in milliseconds, so probing would only add latency to List()
+	// (and, via boxctl-vms-agent.sh's periodic poll, to every dashboard
+	// refresh) for a distinction that isn't real there. The remote-cloud
+	// providers below never set it at all: their own Deploy already
+	// blocks on WaitForCloudInit/WaitForSSH before ever returning, so by
+	// the time such a VM shows up in List(), it was already fully ready.
 	SSHReady bool
 	// Location is the location of the instance
 	Location string

--- a/pkg/cloud/fc.go
+++ b/pkg/cloud/fc.go
@@ -226,18 +226,10 @@ type fcVM struct {
 	// VM name) is all "resume elsewhere" needs.
 	SnapshotStatePath   string `json:"snapshotStatePath,omitempty"`
 	SnapshotMemFilePath string `json:"snapshotMemFilePath,omitempty"`
-	// SSHPort is the guest's SSH port, persisted so List()'s SSHReady
-	// probe (see reconcileSSHReady) targets the right one instead of
-	// assuming 22 -- falls back to 22 itself when zero (a legacy record
-	// predating this field, or a caller that never set Vm.SSHPort).
+	// SSHPort is the guest's SSH port, reported as Vm.SSHPort (mapFCVM) --
+	// falls back to 22 itself when zero (a legacy record predating this
+	// field, or a caller that never set Vm.SSHPort).
 	SSHPort int `json:"sshPort,omitempty"`
-	// SSHReady is set once List() confirms this VM's SSH port is
-	// reachable (see cloud.ProbeSSHReady) -- never reset back to false
-	// once true, since this only exists to distinguish "still booting"
-	// from "actually ready," not to track live reachability from moment
-	// to moment (that's what Status/isAlive already do, via a different,
-	// cheaper signal: process liveness, not a network probe).
-	SSHReady bool `json:"sshReady,omitempty"`
 }
 
 func (p ProviderFC) vmDir(name string) string {
@@ -312,15 +304,24 @@ func (p ProviderFC) loadAndReconcile(path string) (fcVM, error) {
 
 func mapFCVM(vm fcVM) Vm {
 	return Vm{
-		Provider:  "fc",
-		ID:        vm.Name,
-		Name:      vm.Name,
-		IP:        vm.IPAddress,
-		Type:      fmt.Sprintf("%dvcpu-%dmb", vm.VCPUCount, vm.MemSizeMib),
-		Image:     vm.RootfsPath,
-		Status:    vm.Status,
-		SSHPort:   vm.SSHPort,
-		SSHReady:  vm.SSHReady,
+		Provider: "fc",
+		ID:       vm.Name,
+		Name:     vm.Name,
+		IP:       vm.IPAddress,
+		Type:     fmt.Sprintf("%dvcpu-%dmb", vm.VCPUCount, vm.MemSizeMib),
+		Image:    vm.RootfsPath,
+		Status:   vm.Status,
+		SSHPort:  vm.SSHPort,
+		// Unlike ch (see ProviderCH.reconcileSSHReady), fc does not
+		// TCP-probe to compute this: a Firecracker microVM boots in
+		// milliseconds (the whole point of the technology -- see the
+		// dashboard's own "boot in milliseconds" copy), so by the time
+		// any caller sees this VM at all, Status=="running" is already an
+		// accurate-enough proxy for "the guest is reachable." Probing
+		// anyway would only add needless latency to List() (and, via
+		// boxctl-vms-agent.sh's periodic poll, to every dashboard refresh)
+		// for a distinction that isn't real for this provider.
+		SSHReady:  vm.Status == fcStatusRunning,
 		CreatedAt: vm.CreatedAt,
 	}
 }
@@ -892,7 +893,6 @@ func (p ProviderFC) List() (VmList, error) {
 	if err != nil {
 		return VmList{}, err
 	}
-	p.reconcileSSHReady(all)
 	var list VmList
 	for _, vm := range all {
 		if vm.Status == fcStatusPaused {
@@ -901,24 +901,6 @@ func (p ProviderFC) List() (VmList, error) {
 		list.List = append(list.List, mapFCVM(vm))
 	}
 	return list, nil
-}
-
-// reconcileSSHReady mirrors ProviderCH.reconcileSSHReady -- see its doc
-// comment.
-func (p ProviderFC) reconcileSSHReady(all []fcVM) {
-	candidates := make([]Vm, len(all))
-	for i, vm := range all {
-		if vm.Status == fcStatusRunning && !vm.SSHReady {
-			candidates[i] = Vm{IP: vm.IPAddress, SSHPort: vm.SSHPort}
-		}
-	}
-	ready := ProbeSSHReady(candidates)
-	for i := range ready {
-		all[i].SSHReady = true
-		if err := saveFCMetadata(p.metadataPath(all[i].Name), all[i]); err != nil {
-			log.Println("[DEBUG] failed to persist SSHReady for " + all[i].Name + ": " + err.Error())
-		}
-	}
 }
 
 // ListPaused returns all paused managed microVMs.

--- a/pkg/cloud/fc_test.go
+++ b/pkg/cloud/fc_test.go
@@ -389,6 +389,26 @@ func TestProviderFC_List_ReconcilesDeadProcess(t *testing.T) {
 	assert.Equal(t, fcStatusDead, meta.Status, "status should self-heal on disk")
 }
 
+// TestProviderFC_List_SSHReadyMirrorsStatus is a regression test for a
+// deliberate difference from ch: fc's List() must NOT TCP-probe for
+// SSHReady (see mapFCVM's doc comment -- a Firecracker microVM boots in
+// milliseconds, so Status=="running" is already an accurate-enough proxy,
+// and probing would only add needless latency to every List() call). A
+// freshly deployed VM here has no real, reachable IP at all (the fake
+// test harness never assigns one) -- if List() were still probing, this
+// VM would incorrectly come back SSHReady=false; asserting it comes back
+// true instead proves the probe path is gone, not just untested.
+func TestProviderFC_List_SSHReadyMirrorsStatus(t *testing.T) {
+	p, _, _, _, _ := newTestFCProvider(t)
+	_, err := p.Deploy(Vm{Name: "test-vm"})
+	require.NoError(t, err)
+
+	list, err := p.List()
+	require.NoError(t, err)
+	require.Len(t, list.List, 1)
+	assert.True(t, list.List[0].SSHReady, "fc SSHReady must mirror Status==running, not a real probe")
+}
+
 // TestProviderFC_Deploy_RecreatesStaleRecord verifies that Deploy() does not
 // silently no-op when a same-named microVM's record exists but its process
 // is dead — it should clean up the stale state and boot a fresh microVM.


### PR DESCRIPTION
## Summary
- #1105 added a real TCP-probe for `Vm.SSHReady` to both `fc` and `ch`'s `List()`.
- Reported live: unnecessary added latency on the Linux/`fc` side, where the whole "still booting" gap this exists for basically doesn't happen -- a Firecracker microVM boots in milliseconds.
- `fc`'s `List()` no longer probes at all; `Vm.SSHReady` is derived straight from `Status` in `mapFCVM` instead.
- `ch` (Cloud Hypervisor/Windows, where boots genuinely can take minutes) is unchanged -- still does the real probe from #1105.

## Test plan
- [x] `go build ./...`, `go vet ./pkg/cloud/...`, `gofmt -l` clean, `go test ./pkg/cloud/...` passes
- [x] New regression test (`TestProviderFC_List_SSHReadyMirrorsStatus`) deploys a VM with no real reachable IP and confirms `List()` still reports `SSHReady: true` -- proving the probe path is actually gone, not just untested

🤖 Generated with [Claude Code](https://claude.com/claude-code)