### PR TITLE
fix: prefer IPv4 over IPv6 for OVH instance public IP

### DIFF
--- a/pkg/cloud/ovh.go
+++ b/pkg/cloud/ovh.go
@@ -382,7 +382,13 @@ func mapOvhInstance(inst ovhInstance) Vm {
 	for _, addr := range inst.IPAddresses {
 		switch addr.Type {
 		case "public":
-			ip = addr.IP
+			// OVH instances typically carry both an IPv4 and IPv6 public
+			// address; prefer IPv4 (Version 4) since IPv6 reachability to
+			// the guest isn't guaranteed (routing/DHCPv6 timing), and only
+			// fall back to whatever's available if no IPv4 address exists.
+			if ip == "" || addr.Version == 4 {
+				ip = addr.IP
+			}
 		case "private":
 			privateIP = addr.IP
 		}

--- a/pkg/cloud/ovh_test.go
+++ b/pkg/cloud/ovh_test.go
@@ -278,4 +278,37 @@ func TestMapOvhInstance(t *testing.T) {
 		})
 		assert.Equal(t, "N/A", vm.PrivateIP)
 	})
+
+	t.Run("prefers IPv4 over IPv6 regardless of order", func(t *testing.T) {
+		// OVH instances get both a public IPv4 and IPv6 address; SSH must
+		// use the IPv4 one since IPv6 reachability to the guest isn't
+		// guaranteed. Order in the API response shouldn't matter.
+		vmIPv6First := mapOvhInstance(ovhInstance{
+			ID: "1", Name: "vm1",
+			IPAddresses: []ovhIPAddress{
+				{IP: "2001:41d0:304:300::9ed", Type: "public", Version: 6},
+				{IP: "203.0.113.1", Type: "public", Version: 4},
+			},
+		})
+		assert.Equal(t, "203.0.113.1", vmIPv6First.IP)
+
+		vmIPv4First := mapOvhInstance(ovhInstance{
+			ID: "1", Name: "vm1",
+			IPAddresses: []ovhIPAddress{
+				{IP: "203.0.113.1", Type: "public", Version: 4},
+				{IP: "2001:41d0:304:300::9ed", Type: "public", Version: 6},
+			},
+		})
+		assert.Equal(t, "203.0.113.1", vmIPv4First.IP)
+	})
+
+	t.Run("falls back to IPv6 when no IPv4 public address exists", func(t *testing.T) {
+		vm := mapOvhInstance(ovhInstance{
+			ID: "1", Name: "vm1",
+			IPAddresses: []ovhIPAddress{
+				{IP: "2001:41d0:304:300::9ed", Type: "public", Version: 6},
+			},
+		})
+		assert.Equal(t, "2001:41d0:304:300::9ed", vm.IP)
+	})
 }


### PR DESCRIPTION
## Summary
- OVH instances return both a public IPv4 and IPv6 address; `mapOvhInstance` picked whichever came last in the API response, which could select IPv6 and cause SSH/cloud-init readiness checks to time out (reproduced live: `onctl up` selected `2001:41d0:...` and hung waiting for cloud-init).
- Now explicitly prefers the `Version == 4` address, falling back to IPv6 only if no IPv4 public address exists.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/cloud/... -run TestMapOvhInstance -v` (added cases for both address orderings + IPv6-only fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QcAgr8V7YPyPVz5qmEcnDV