### PR TITLE
build: add macOS (darwin) builds to edge release

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -17,8 +17,8 @@ name: edge
 # goreleaser-pro) + commented-out GORELEASER_KEY confirm this repo is on
 # the free tier. So this uses the OSS `--snapshot` flag instead (builds
 # unversioned artifacts, skips all publishing/validation) against a
-# dedicated .goreleaser.edge.yml (Linux only -- no macOS or Windows
-# build, no quill signing, no homebrew tap publish, none of which apply here),
+# dedicated .goreleaser.edge.yml (includes Linux and macOS, no quill signing,
+# no homebrew tap publish, none of which apply here),
 # then this workflow publishes the result itself: deletes and recreates a
 # single rolling `edge` prerelease/tag on every run, so there's always
 # exactly one, always-current release at a fixed URL

--- a/.goreleaser.edge.yml
+++ b/.goreleaser.edge.yml
@@ -6,12 +6,8 @@ project_name: onctl
 # (real tagged releases: GPG-signed checksums, Apple-notarized macOS
 # binaries, homebrew tap publish). None of that applies to an edge build,
 # so it's a dedicated config rather than reusing goreleaser.yml with skip
-# flags -- Linux only (no macOS build: no quill/notarization credentials
-# needed, and the hosts consuming edge builds today, e.g. aimax, are Linux
-# anyway; no Windows build either -- nothing currently consumes it, and
-# every target GoReleaser builds runs in parallel on the self-hosted
-# onctl-4 runner this workflow builds on, so dropping it also helps keep
-# peak memory down alongside --parallelism=1 in edge.yml), no signs
+# flags -- includes Linux and macOS (no quill/notarization credentials needed,
+# no homebrew tap publish, none of which apply here), no signs
 # section, no homebrew_casks.
 
 before:
@@ -25,6 +21,7 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - darwin
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
This PR adds macOS (darwin) builds for both amd64 and arm64 architectures to the edge release pipeline in .goreleaser.edge.yml. It also updates the relevant comments in .github/workflows/edge.yml and .goreleaser.edge.yml.